### PR TITLE
Allow SQS message handlers to be configured from the graph.

### DIFF
--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -59,7 +59,20 @@ class SQSMessageDispatcher(object):
     mappings=dict(),
 )
 def configure_sqs_message_dispatcher(graph):
+    """
+    Configure dispatching of SQS messages.
+
+    Requires a dictionary mapping from the message media type to a handler function; unmapped
+    messages will be ignored. This dictionary can either be defined using the `sqs_message_dispatcher.mappings`
+    configuration key (which is convenient for simple handlers) or, more likely, via a separate
+    `sqs_message_handlers` graph component (which is convenient of the handlers need other component collaborators).
+    """
+    try:
+        sqs_message_handlers = graph.sqs_message_handlers
+    except AttributeError:
+        sqs_message_handlers = graph.config.sqs_message_dispatcher.mappings
+
     return SQSMessageDispatcher(
         sqs_consumer=graph.sqs_consumer,
-        sqs_message_handlers=graph.config.sqs_message_dispatcher.mappings,
+        sqs_message_handlers=sqs_message_handlers,
     )


### PR DESCRIPTION
My earlier attempt at wiring in SQS message handlers turned out to occur before the graph was even created, so I'm doing the right thing and making it possible for the handler mapping to be a graph component.