### PR TITLE
Tune SQS consumer behavior by setting a wait timeout of 1s.

### DIFF
--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -147,7 +147,7 @@ class SQSConsumer(object):
     # SQS will not return more than ten messages at a time
     limit=10,
     # SQS will only return a few messages at time unless long polling is enabled (>0)
-    wait_seconds=0,
+    wait_seconds=1,
 )
 def configure_sqs_consumer(graph):
     """

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from logging import getLogger
 
 from microcosm.api import defaults
+from microcosm.errors import NotBoundError
 
 
 DispatchResult = namedtuple("DispatchResult", ["message_count", "error_count", "ignore_count"])
@@ -69,7 +70,7 @@ def configure_sqs_message_dispatcher(graph):
     """
     try:
         sqs_message_handlers = graph.sqs_message_handlers
-    except AttributeError:
+    except NotBoundError:
         sqs_message_handlers = graph.config.sqs_message_dispatcher.mappings
 
     return SQSMessageDispatcher(

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "console_scripts": [
             "sns-produce = microcosm_pubsub.main:produce",
             "sqs-consume = microcosm_pubsub.main:consume",
+            "simple-daemon = microcosm_pubsub.main:main",
         ],
         "microcosm.factories": [
             "pubsub_message_codecs = microcosm_pubsub.codecs:configure_pubsub_message_codecs",


### PR DESCRIPTION
Setting to zero (the previous behavior) fails to wait long enough for new messages to appear;
this causes long delays on message delivery. Setting to larger values causes the daemon to block
waiting on SQS; this interferes with daemon interruption and shutdown.

At the same time: add the simple daemon from the README to the examples and modify the example
message to better enable diagnostics.