### PR TITLE
uuid field type + its tests

### DIFF
--- a/microcosm_pubsub/fields.py
+++ b/microcosm_pubsub/fields.py
@@ -10,10 +10,6 @@ class UUIDField(Field):
     UUID valued field, as either a string or UUID object.
 
     """
-    def __init__(self, use_uuidformat=False, *args, **kwargs):
-        self.use_uuidformat = use_uuidformat
-        super(UUIDField, self).__init__(*args, **kwargs)
-
     def _serialize(self, value, attr, obj):
         """
         Serialize value as a uuid, either as a string or an UUID object.
@@ -21,7 +17,7 @@ class UUIDField(Field):
         if value is None:
             return None
 
-        if self.use_uuidformat:
+        if isinstance(value, UUID):
             return str(value)
         else:
             return value
@@ -36,7 +32,7 @@ class UUIDField(Field):
             return None
 
         try:
-            if self.use_uuidformat:
+            if isinstance(value, UUID):
                 return str(value)
             else:
                 return str(UUID(value))

--- a/microcosm_pubsub/fields.py
+++ b/microcosm_pubsub/fields.py
@@ -1,0 +1,45 @@
+"""
+Custom fields.
+"""
+from marshmallow.fields import Field, ValidationError
+from uuid import UUID
+
+
+class UUIDField(Field):
+    """
+    UUID valued field, as either a string or UUID object.
+
+    """
+    def __init__(self, use_uuidformat=False, *args, **kwargs):
+        self.use_uuidformat = use_uuidformat
+        super(UUIDField, self).__init__(*args, **kwargs)
+
+    def _serialize(self, value, attr, obj):
+        """
+        Serialize value as a uuid, either as a string or an UUID object.
+        """
+        if value is None:
+            return None
+
+        if self.use_uuidformat:
+            return str(value)
+        else:
+            return value
+
+    def _deserialize(self, value, attr, data):
+        """
+        Deserialize value as a uuid.
+
+        Handle both string and UUID object.
+        """
+        if value is None:
+            return None
+
+        try:
+            if self.use_uuidformat:
+                return str(value)
+            else:
+                return str(UUID(value))
+
+        except ValueError:
+            raise ValidationError('Not a valid UUID.')

--- a/microcosm_pubsub/tests/test_fields.py
+++ b/microcosm_pubsub/tests/test_fields.py
@@ -21,7 +21,7 @@ INVALID_UUID_STR = 'INVALID_UUID_STRING'
 
 class UUIDSchema(Schema):
     uuid_str = UUIDField()
-    uuid_uuid = UUIDField(use_uuidformat=True)
+    uuid_uuid = UUIDField()
 
 
 def test_uuid_load():

--- a/microcosm_pubsub/tests/test_fields.py
+++ b/microcosm_pubsub/tests/test_fields.py
@@ -40,7 +40,7 @@ def test_uuid_load():
 
 def test_invlalid_uuid_load():
     """
-
+    Desirializing of non-uuid formatted value should raise an erro.
     """
     schema = UUIDSchema()
     result = schema.load({

--- a/microcosm_pubsub/tests/test_fields.py
+++ b/microcosm_pubsub/tests/test_fields.py
@@ -1,0 +1,65 @@
+"""
+Test fields
+
+"""
+from uuid import UUID
+from hamcrest import (
+    assert_that,
+    contains,
+    equal_to,
+    is_,
+)
+from marshmallow import Schema
+
+from microcosm_pubsub.fields import UUIDField
+
+
+UUID_STR = '051263b8-707a-4561-a114-11d6706ca5d5'
+# UUID_UUID = UUID(UUID_STR)
+INVALID_UUID_STR = 'INVALID_UUID_STRING'
+
+
+class UUIDSchema(Schema):
+    uuid_str = UUIDField()
+    uuid_uuid = UUIDField(use_uuidformat=True)
+
+
+def test_uuid_load():
+    """
+    Can deserialize.
+    """
+    schema = UUIDSchema()
+    result = schema.load({
+        "uuid_str": UUID_STR,
+        "uuid_uuid": UUID(UUID_STR),
+    })
+
+    assert_that(result.data['uuid_str'], is_(equal_to(UUID_STR)))
+    assert_that(result.data['uuid_uuid'], is_(equal_to(UUID_STR)))
+
+
+def test_invlalid_uuid_load():
+    """
+
+    """
+    schema = UUIDSchema()
+    result = schema.load({
+        "uuid_str": INVALID_UUID_STR,
+        "uuid_uuid": UUID(UUID_STR),
+    })
+
+    assert_that(result.errors["uuid_str"], contains('Not a valid UUID.'))
+
+
+def test_uuid_dump():
+    """
+    Can serialize.
+    """
+    schema = UUIDSchema()
+    result = schema.dump({
+        "uuid_str": UUID_STR,
+        "uuid_uuid": UUID(UUID_STR),
+    })
+
+    assert_that(result.data['uuid_str'], is_(equal_to(UUID_STR)))
+    assert_that(result.data['uuid_uuid'], is_(equal_to(UUID_STR)))


### PR DESCRIPTION
We want to use the this new `UUIDField` in schemas which are using UUID fields (instead of marshmallow's given fields.UUID). The reason for that is that `UUID` type is not json-serializable so pass it through string conversion first.