### PR TITLE
allow for binding a default handler for malformatted messages

### DIFF
--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -6,6 +6,7 @@ from json import loads
 from hashlib import md5
 
 from boto3 import client
+from marshmallow.exceptions import ValidationError
 from microcosm.api import defaults
 
 
@@ -72,7 +73,11 @@ class SQSMessage(object):
         Parse and validate the message.
 
         """
-        base_message = consumer.pubsub_message_codecs["_"].decode(message)
+        try:
+            base_message = consumer.pubsub_message_codecs["_"].decode(message)
+        except ValidationError:
+            return loads(message)
+
         media_type = base_message["mediaType"]
         content = consumer.pubsub_message_codecs[media_type].decode(message)
         return content

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -48,7 +48,7 @@ class SQSMessageDispatcher(object):
         Handle a single message.
 
         """
-        media_type = message["media_type"]
+        media_type = message.get("media_type", "_")
         sqs_message_handler = self.sqs_message_handlers.get(media_type)
         if sqs_message_handler is None:
             logger.debug("Skipping message with unsupported type: {}".format(media_type))


### PR DESCRIPTION
I want to be able to register a `default` handler which can be used when no handler for a desired media type can be found or you *have* to parse a message with no media type.