### PR TITLE
Refactor the envelope parsing from SQS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ PubSub with SNS/SQS
 
 ## CLI
 
-For testing purposes, the producer and consumer functions can be invoked from the CLI.
+For testing purposes, the producer and consumer functions can be invoked from the CLI. These test functions
+use a very simplistic schema and will not work for most real use cases.
 
 To produce messages:
 
@@ -66,8 +67,8 @@ The consumer returns a list of (possibly zero) messages:
 Messages should be explicitly acknowledged after processing:
 
     for message in messages:
-       process(message.content)
-       message.ack()
+        process(message.content)
+        message.ack()
 
 Messages act as context managers; in this mode, messsages will automatically acknowledge themselves if
 no exception is raised during processing:

--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -91,11 +91,9 @@ class PubSubMessageCodec(object):
 
 
 @defaults(
-    default=PubSubMessageSchema,
+    default=None,
     strict=True,
-    mappings=dict(
-        _=MediaTypeSchema,
-    ),
+    mappings=dict(),
 )
 def configure_pubsub_message_codecs(graph):
     """
@@ -105,7 +103,10 @@ def configure_pubsub_message_codecs(graph):
     default_schema_cls = graph.config.pubsub_message_codecs.default
     strict = graph.config.pubsub_message_codecs.strict
 
-    message_codecs = defaultdict(lambda: PubSubMessageCodec(default_schema_cls(strict=strict)))
+    if default_schema_cls:
+        message_codecs = defaultdict(lambda: PubSubMessageCodec(default_schema_cls(strict=strict)))
+    else:
+        message_codecs = dict()
 
     for key, schema_cls in graph.config.pubsub_message_codecs.mappings.items():
         message_codecs[key] = PubSubMessageCodec(schema_cls(strict=strict))

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -2,49 +2,8 @@
 Message consumer.
 
 """
-from json import loads
-from hashlib import md5
-
 from boto3 import client
 from microcosm.api import defaults
-
-from microcosm_pubsub.codecs import MediaTypeSchema, PubSubMessageCodec
-
-
-class SQSMessage(object):
-    """
-    SQS message wrapper.
-
-    """
-    def __init__(self, consumer, content, media_type, message_id, receipt_handle):
-        self.consumer = consumer
-        self.content = content
-        self.media_type = media_type
-        self.message_id = message_id
-        self.receipt_handle = receipt_handle
-
-    def ack(self):
-        """
-        Acknowledge this message was processed successfully.
-
-        """
-        self.consumer.ack(self)
-
-    def nack(self):
-        """
-        Acknowledge this message was NOT processed successfully.
-
-        """
-        self.consumer.nack(self)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        if type is None:
-            self.ack()
-        else:
-            self.nack()
 
 
 class SQSConsumer(object):
@@ -52,10 +11,15 @@ class SQSConsumer(object):
     Consume message from a (single) SQS queue.
 
     """
-    def __init__(self, sqs_client, sqs_queue_url, pubsub_message_codecs, limit, wait_seconds):
+    def __init__(self,
+                 sqs_client,
+                 sqs_envelope,
+                 sqs_queue_url,
+                 limit,
+                 wait_seconds):
         self.sqs_client = sqs_client
+        self.sqs_envelope = sqs_envelope
         self.sqs_queue_url = sqs_queue_url
-        self.pubsub_message_codecs = pubsub_message_codecs
         self.limit = limit
         self.wait_seconds = wait_seconds
 
@@ -66,8 +30,8 @@ class SQSConsumer(object):
         :returns: a list of `SQSMessage`
         """
         return [
-            self._from_sqs(message)
-            for message in self.sqs_client.receive_message(
+            self.sqs_envelope.parse_raw_message(self, raw_message)
+            for raw_message in self.sqs_client.receive_message(
                 QueueUrl=self.sqs_queue_url,
                 MaxNumberOfMessages=self.limit,
                 WaitTimeSeconds=self.wait_seconds,
@@ -95,56 +59,6 @@ class SQSConsumer(object):
         """
         pass
 
-    def _from_sqs(self, sqs_message, validate_md5=False):
-        """
-        Create an `SQSMessage` from SQS data.
-
-        """
-        message_id = sqs_message["MessageId"]
-        receipt_handle = sqs_message["ReceiptHandle"]
-        body = sqs_message["Body"]
-
-        if validate_md5:
-            self._validate_md5(sqs_message, body)
-
-        message = loads(body)["Message"]
-        media_type, content = self._parse_message_from_sqs(message)
-
-        return SQSMessage(
-            consumer=self,
-            content=content,
-            media_type=media_type,
-            message_id=message_id,
-            receipt_handle=receipt_handle,
-        )
-
-    def _parse_message_from_sqs(self, message):
-        """
-        Parse and validate SQS message content.
-
-        :returns: a media_type, content tuple
-
-        """
-        base_message = PubSubMessageCodec(MediaTypeSchema()).decode(message)
-        media_type = base_message["mediaType"]
-        content = self.pubsub_message_codecs[media_type].decode(message)
-        return media_type, content
-
-    def _validate_md5(self, sqs_message, body):
-        """
-        Validate the message body.
-
-        Just checks for tampering; schema validation occurs once we know the type of message.
-
-        """
-        expected_md5_of_body = sqs_message["MD5OfBody"]
-        actual_md5_of_body = md5(body).hexdigest()
-        if expected_md5_of_body != actual_md5_of_body:
-            raise Exception("MD5 validation failed. Expected: {} Actual: {}".format(
-                expected_md5_of_body,
-                actual_md5_of_body,
-            ))
-
 
 @defaults(
     # SQS will not return more than ten messages at a time
@@ -169,8 +83,8 @@ def configure_sqs_consumer(graph):
 
     return SQSConsumer(
         sqs_client=sqs_client,
+        sqs_envelope=graph.sqs_envelope,
         sqs_queue_url=sqs_queue_url,
-        pubsub_message_codecs=graph.pubsub_message_codecs,
         limit=limit,
         wait_seconds=wait_seconds,
     )

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -35,7 +35,7 @@ class SQSMessageDispatcher(object):
             message_count += 1
             try:
                 with message:
-                    if not self.handle_message(message.content):
+                    if not self.handle_message(message.media_type, message.content):
                         ignore_count += 1
             except Exception:
                 logger.info("Error handling SQS message.", exc_info=True)
@@ -43,12 +43,11 @@ class SQSMessageDispatcher(object):
 
         return DispatchResult(message_count, error_count, ignore_count)
 
-    def handle_message(self, message):
+    def handle_message(self, media_type, message):
         """
         Handle a single message.
 
         """
-        media_type = message["media_type"]
         sqs_message_handler = self.sqs_message_handlers.get(media_type)
         if sqs_message_handler is None:
             logger.debug("Skipping message with unsupported type: {}".format(media_type))

--- a/microcosm_pubsub/envelope.py
+++ b/microcosm_pubsub/envelope.py
@@ -1,0 +1,130 @@
+"""
+Parse the SQS envelope.
+
+SQS defines an envelope with a message id, receipt handle, body, and so forth,
+with the underlying message embedded in the body. There are multiple ways to
+process this envelope, depending on the degree of validation and metadata desired.
+
+"""
+from abc import ABCMeta, abstractmethod
+from json import loads
+from hashlib import md5
+
+from microcosm.api import defaults
+
+from microcosm_pubsub.codecs import MediaTypeSchema, PubSubMessageCodec
+from microcosm_pubsub.message import SQSMessage
+
+
+class SQSEnvelope(object):
+    """
+    Enveloping base class.
+
+    """
+    __metaclass__ = ABCMeta
+
+    def __init__(self, graph):
+        self.pubsub_message_codecs = graph.pubsub_message_codecs
+        self.validate_md5 = graph.config.sqs_envelope.validate_md5
+
+    def parse_raw_message(self, consumer, raw_message):
+        """
+        Create an `SQSMessage` from SQS data.
+
+        """
+        message_id = raw_message["MessageId"]
+        receipt_handle = raw_message["ReceiptHandle"]
+        body = raw_message["Body"]
+
+        if self.validate_md5:
+            self.validate_md5(raw_message, body)
+
+        message = loads(body)["Message"]
+        media_type, content = self.parse_media_type_and_content(message)
+
+        return SQSMessage(
+            consumer=consumer,
+            content=content,
+            media_type=media_type,
+            message_id=message_id,
+            receipt_handle=receipt_handle,
+        )
+
+    @abstractmethod
+    def parse_media_type_and_content(self, message):
+        """
+        Parse and validate SQS message media type and content.
+
+        :returns: a media_type, content tuple
+
+        """
+        pass
+
+    def validate_md5(self, raw_message, body):
+        """
+        Validate the message body.
+
+        Just checks for tampering; schema validation occurs once we know the type of message.
+
+        """
+        expected_md5_of_body = raw_message["MD5OfBody"]
+        actual_md5_of_body = md5(body).hexdigest()
+        if expected_md5_of_body != actual_md5_of_body:
+            raise Exception("MD5 validation failed. Expected: {} Actual: {}".format(
+                expected_md5_of_body,
+                actual_md5_of_body,
+            ))
+
+
+class RawSQSEnvelope(SQSEnvelope):
+    """
+    Enveloping strategy that just passes raw JSON.
+
+    """
+    def parse_media_type_and_content(self, message):
+        content = loads(message)
+        media_type = "application/json"
+        return media_type, content
+
+
+class CodecSQSEnvelope(SQSEnvelope):
+    """
+    Enveloping strategy that uses a media type-driven message codec.
+
+    """
+    def __init__(self, graph):
+        super(CodecSQSEnvelope, self).__init__(graph)
+        self.media_type_codec = PubSubMessageCodec(MediaTypeSchema())
+
+    def parse_media_type_and_content(self, message):
+        """
+        Decode the message once to extract its media type and then again with the correct codec.
+
+        """
+        base_message = self.media_type_codec.decode(message)
+        media_type = base_message["mediaType"]
+        content = self.pubsub_message_codecs[media_type].decode(message)
+        return media_type, content
+
+
+@defaults(
+    strategy_name="CodecSQSEnvelope",
+    validate_md5=False,
+)
+def configure_sqs_envelope(graph):
+    strategy_name = graph.config.sqs_envelope.strategy_name
+    # It should be possible to inject custom enveloping strategies as long as the
+    # subclass is imported before the graph is initialized; alternative, this block
+    # can be switched to using setuptools entry points.
+    strategies = {
+        strategy.__name__: strategy
+        for strategy in SQSEnvelope.__subclasses__()
+    }
+    try:
+        strategy = strategies[strategy_name]
+    except KeyError:
+        raise Exception("Unknown SQS enveloping strategy: {}".format(
+            strategy_name,
+        ))
+    else:
+        return strategy(graph)

--- a/microcosm_pubsub/message.py
+++ b/microcosm_pubsub/message.py
@@ -1,0 +1,40 @@
+"""
+A single SQS message.
+
+"""
+
+
+class SQSMessage(object):
+    """
+    SQS message wrapper.
+
+    """
+    def __init__(self, consumer, content, media_type, message_id, receipt_handle):
+        self.consumer = consumer
+        self.content = content
+        self.media_type = media_type
+        self.message_id = message_id
+        self.receipt_handle = receipt_handle
+
+    def ack(self):
+        """
+        Acknowledge this message was processed successfully.
+
+        """
+        self.consumer.ack(self)
+
+    def nack(self):
+        """
+        Acknowledge this message was NOT processed successfully.
+
+        """
+        self.consumer.nack(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if type is None:
+            self.ack()
+        else:
+            self.nack()

--- a/microcosm_pubsub/tests/fixtures.py
+++ b/microcosm_pubsub/tests/fixtures.py
@@ -14,7 +14,9 @@ RECEIPT_HANDLE = "receipt-handle"
 
 
 class FooSchema(PubSubMessageSchema):
+    MEDIA_TYPE = FOO_MEDIA_TYPE
+
     bar = fields.String(required=True)
 
     def deserialize_media_type(self, obj):
-        return FOO_MEDIA_TYPE
+        return FooSchema.MEDIA_TYPE

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -89,9 +89,10 @@ def test_ack():
     graph = create_object_graph("example", testing=True, loader=loader)
     message = SQSMessage(
         consumer=graph.sqs_consumer,
+        content=None,
+        media_type=FooSchema.MEDIA_TYPE,
         message_id=MESSAGE_ID,
         receipt_handle=RECEIPT_HANDLE,
-        content=None,
     )
     message.ack()
     graph.sqs_consumer.sqs_client.delete_message.assert_called_with(

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -12,7 +12,7 @@ from hamcrest import (
 )
 from microcosm.api import create_object_graph
 
-from microcosm_pubsub.consumer import SQSMessage
+from microcosm_pubsub.message import SQSMessage
 from microcosm_pubsub.tests.fixtures import (
     FOO_QUEUE_URL,
     FOO_MEDIA_TYPE,

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "microcosm.factories": [
             "pubsub_message_codecs = microcosm_pubsub.codecs:configure_pubsub_message_codecs",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",
+            "sqs_envelope = microcosm_pubsub.envelope:configure_sqs_envelope",
             "sqs_message_dispatcher = microcosm_pubsub.dispatcher:configure_sqs_message_dispatcher",
             "sns_producer = microcosm_pubsub.producer:configure_sns_producer",
             "sns_topic_arns = microcosm_pubsub.producer:configure_sns_topic_arns",


### PR DESCRIPTION
Main changes:
 - Moved parsing functions to new module instead of classmethods of the SQSMessage object.
 - Use subclasses of `SQSEnvelope` for alternate parsing patterns
 - Explicitly use the MediaTypeSchema instead of depending on `_` naming convention.
 - Add raw parsing of envelope as JSON
 - Remove the default usage of a default schema. (Unrelated, but a good idea.)