### PR TITLE
Usage of opaque data.

### DIFF
--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -26,6 +26,7 @@ class PubSubMessageSchema(Schema):
         # need to set missing to non-None or marshmallow won't call the deserialize function
         missing=DEFAULT_MEDIA_TYPE,
     )
+    opaque_data = fields.Dict(required=False)
 
     def serialize_media_type(self, message):
         """

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -4,6 +4,7 @@ Consume Daemon main.
 """
 from abc import abstractproperty
 
+import microcosm.opaque  # noqa
 from microcosm_daemon.api import SleepNow
 from microcosm_daemon.daemon import Daemon
 
@@ -58,6 +59,7 @@ class ConsumerDaemon(Daemon):
     @property
     def components(self):
         return super(ConsumerDaemon, self).components + [
+            "opaque",
             "pubsub_message_codecs",
             "sqs_consumer",
             "sqs_message_dispatcher",

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -96,6 +96,12 @@ def configure_sqs_message_dispatcher(graph):
             return dict()
         sqs_message_context = context
 
+    if graph.metadata.testing:
+        from mock import MagicMock
+        opaque = MagicMock(data_func=MagicMock(return_value=dict()))
+    else:
+        opaque = graph.opaque
+
     return SQSMessageDispatcher(
         opaque=opaque,
         sqs_consumer=graph.sqs_consumer,

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -68,7 +68,7 @@ class SQSMessageDispatcher(object):
             sqs_message_handler,
             parent=sqs_message_handler,
         )
-        with self.opaque.bind(self.sqs_message_context, message):
+        with self.opaque.initialize(self.sqs_message_context, message):
             return handler_with_context(message)
 
 

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -68,7 +68,7 @@ class SQSMessageDispatcher(object):
             sqs_message_handler,
             parent=sqs_message_handler,
         )
-        with self.opaque.opaque_data(self.sqs_message_context, message):
+        with self.opaque.bind(self.sqs_message_context, message):
             return handler_with_context(message)
 
 
@@ -98,7 +98,7 @@ def configure_sqs_message_dispatcher(graph):
 
     if graph.metadata.testing:
         from mock import MagicMock
-        opaque = MagicMock(data_func=MagicMock(return_value=dict()))
+        opaque = MagicMock(bind=MagicMock())
     else:
         opaque = graph.opaque
 

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -28,7 +28,7 @@ class SNSProducer(object):
         :returns: the message id
 
         """
-        kwargs.setdefault('opaque_data', self.opaque.data_func())
+        kwargs.setdefault('opaque_data', self.opaque.as_dict())
         topic_arn = self.choose_topic_arn(media_type)
         content = self.pubsub_message_codecs[media_type].encode(dct, **kwargs)
         result = self.sns_client.publish(
@@ -86,7 +86,7 @@ def configure_sns_producer(graph):
 
     if graph.metadata.testing:
         from mock import MagicMock
-        opaque = MagicMock(data_func=MagicMock(return_value=dict()))
+        opaque = MagicMock(as_dict=MagicMock(return_value=dict()))
     else:
         opaque = graph.opaque
 

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -77,6 +77,12 @@ def configure_sns_producer(graph):
     """
     Configure an SNS producer.
 
+    The SNS Producer requires the following collaborators:
+        - Opaque from microcosm.opaque for capturing context information
+        - an aws sns client, i.e. from boto.
+        - pubsub message codecs: see tests for examples.
+        - sns topic arns: see tests for examples.
+
     """
     if graph.metadata.testing:
         from mock import MagicMock

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -15,10 +15,11 @@ class SNSProducer(object):
     Produces messages to SNS topics.
 
     """
-    def __init__(self, sns_client, sns_topic_arns, pubsub_message_codecs):
+    def __init__(self, opaque, pubsub_message_codes, sns_client, sns_topic_arns):
+        self.opaque = opaque
+        self.pubsub_message_codecs = pubsub_message_codecs
         self.sns_client = sns_client
         self.sns_topic_arns = sns_topic_arns
-        self.pubsub_message_codecs = pubsub_message_codecs
 
     def produce(self, media_type, dct=None, **kwargs):
         """
@@ -27,6 +28,7 @@ class SNSProducer(object):
         :returns: the message id
 
         """
+        dct.setdefault('opaque_data', self.opaque.opaque_data_func())
         topic_arn = self.choose_topic_arn(media_type)
         content = self.pubsub_message_codecs[media_type].encode(dct, **kwargs)
         result = self.sns_client.publish(
@@ -83,7 +85,8 @@ def configure_sns_producer(graph):
         sns_client = client("sns")
 
     return SNSProducer(
+        opaque=graph.opaque,
+        pubsub_message_codecs=graph.pubsub_message_codecs,
         sns_client=sns_client,
         sns_topic_arns=graph.sns_topic_arns,
-        pubsub_message_codecs=graph.pubsub_message_codecs,
     )

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -70,6 +70,7 @@ def test_produce_default_topic():
     assert_that(loads(graph.sns_producer.sns_client.publish.call_args[1]["Message"]), is_(equal_to({
         "bar": "baz",
         "mediaType": "application/vnd.globality.pubsub.foo",
+        "opaque_data": {},
     })))
     assert_that(message_id, is_(equal_to(MESSAGE_ID)))
 
@@ -104,5 +105,6 @@ def test_produce_custom_topic():
     assert_that(loads(graph.sns_producer.sns_client.publish.call_args[1]["Message"]), is_(equal_to({
         "bar": "baz",
         "mediaType": "application/vnd.globality.pubsub.foo",
+        "opaque_data": {},
     })))
     assert_that(message_id, is_(equal_to(MESSAGE_ID)))

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -12,6 +12,7 @@ from hamcrest import (
     raises,
 )
 from microcosm.api import create_object_graph
+import microcosm.opaque  # noqa
 
 from microcosm_pubsub.errors import TopicNotDefinedError
 from microcosm_pubsub.tests.fixtures import (
@@ -59,6 +60,7 @@ def test_produce_default_topic():
         )
 
     graph = create_object_graph("example", testing=True, loader=loader)
+    graph.use("opaque")
 
     # set up response
     graph.sns_producer.sns_client.publish.return_value = dict(MessageId=MESSAGE_ID)
@@ -94,6 +96,7 @@ def test_produce_custom_topic():
         )
 
     graph = create_object_graph("example", testing=True, loader=loader)
+    graph.use("opaque")
 
     # set up response
     graph.sns_producer.sns_client.publish.return_value = dict(MessageId=MESSAGE_ID)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         "boto3>=1.3.0",
         "marshmallow>=2.6.1",
-        "microcosm>=0.7.0",
+        "microcosm>=0.12.0",
         "microcosm-daemon>=0.2.0",
     ],
     setup_requires=[


### PR DESCRIPTION
This is an example usage of: https://github.com/globality-corp/microcosm/pull/12

@jessemyers  I see the value of your comments about api fluency here. For one thing, it would allow me to clean up the mocking of opaque by factories when the graph is instantiated in test mode. I.e. right now I have to do:

```
    if graph.metadata.testing:
        from mock import MagicMock
        opaque = MagicMock(data_func=MagicMock(return_value=dict()))
    else:
        opaque = graph.opaque
```

And with your recommendation I would be able to do:

```
    if graph.metadata.testing:
        from mock import MagicMock
        opaque = dict()
    else:
        opaque = graph.opaque
```
