### PR TITLE
Make failed message available immediately

### DIFF
--- a/microcosm_pubsub/main.py
+++ b/microcosm_pubsub/main.py
@@ -71,6 +71,7 @@ def consume():
             ),
             sqs_consumer=dict(
                 sqs_queue_url=args.queue_url,
+                visibility_timeout_seconds=None,
             ),
         )
 

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -31,6 +31,7 @@ def test_consume():
         return dict(
             sqs_consumer=dict(
                 sqs_queue_url=FOO_QUEUE_URL,
+                visibility_timeout_seconds=None,
             ),
             pubsub_message_codecs=dict(
                 default=FooSchema,
@@ -71,6 +72,68 @@ def test_consume():
     ))))
 
 
+def test_nack_without_visibility_timeout():
+    """
+    Consumer passes
+
+    """
+    def loader(metadata):
+        return dict(
+            sqs_consumer=dict(
+                sqs_queue_url=FOO_QUEUE_URL,
+                visibility_timeout_seconds=None,
+            ),
+            pubsub_message_codecs=dict(
+                default=FooSchema,
+            ),
+        )
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+    message = SQSMessage(
+        consumer=graph.sqs_consumer,
+        content=None,
+        media_type=FooSchema.MEDIA_TYPE,
+        message_id=MESSAGE_ID,
+        receipt_handle=RECEIPT_HANDLE,
+    )
+    message.nack()
+    graph.sqs_consumer.sqs_client.change_message_visibility.assert_not_called()
+
+
+def test_nack_with_visibility_timeout():
+    """
+    Consumer delegates to SQS client with visibility timeout
+
+    """
+    visibility_timeout_seconds = 2
+
+    def loader(metadata):
+        return dict(
+            sqs_consumer=dict(
+                sqs_queue_url=FOO_QUEUE_URL,
+                visibility_timeout_seconds=visibility_timeout_seconds,
+            ),
+            pubsub_message_codecs=dict(
+                default=FooSchema,
+            ),
+        )
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+    message = SQSMessage(
+        consumer=graph.sqs_consumer,
+        content=None,
+        media_type=FooSchema.MEDIA_TYPE,
+        message_id=MESSAGE_ID,
+        receipt_handle=RECEIPT_HANDLE,
+    )
+    message.nack()
+    graph.sqs_consumer.sqs_client.change_message_visibility.assert_called_with(
+        QueueUrl='foo-queue-url',
+        ReceiptHandle=RECEIPT_HANDLE,
+        VisibilityTimeout=visibility_timeout_seconds,
+    )
+
+
 def test_ack():
     """
     Consumer delegates to SQS client.
@@ -80,6 +143,7 @@ def test_ack():
         return dict(
             sqs_consumer=dict(
                 sqs_queue_url=FOO_QUEUE_URL,
+                visibility_timeout_seconds=None,
             ),
             pubsub_message_codecs=dict(
                 default=FooSchema,

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -26,6 +26,7 @@ def test_handle():
         return dict(
             sqs_consumer=dict(
                 sqs_queue_url=FOO_QUEUE_URL,
+                visibility_timeout_seconds=None,
             ),
             pubsub_message_codecs=dict(
                 default=FooSchema,
@@ -63,6 +64,7 @@ def test_handle_with_no_context():
         return dict(
             sqs_consumer=dict(
                 sqs_queue_url=FOO_QUEUE_URL,
+                visibility_timeout_seconds=None,
             ),
             pubsub_message_codecs=dict(
                 default=FooSchema,


### PR DESCRIPTION
Why:

* if we have a queue with a visibility timeout of 30 seconds and
  message processing fails immediately, the message will not be
  available for processing for 30 seconds. This kind of window is
  helpful for handling timeouts as we want to give the job a chance to
  succeed but upon fast failures we want to make the message available
  again.

This change addresses the need by:

* upon failure of processing a job, we call `nack`. With this change,
  `nack` will now change the visibility timeout of the failed message to
  `0`, which makes it immediately available. Per the
  [docs](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ChangeMessageVisibility.html)
  (and see snippet below)
  this setting is not persisted across attempts so the next time the
  message is picked up, its visibility timeout will be set back to the
  queue's default. This behavior is desireable because the second
  attempt at processing will start quickly but then have its normal 30
  seconds to succeed.
* Open question: where should some kind of backoff happen for message
  failure? Should it be here or in `microcosm-daemon`?

```
Unlike with a queue, when you change the visibility timeout for a
specific message, that timeout value is applied immediately but is not
saved in memory for that message. If you don't delete a message after it
is received, the visibility timeout for the message the next time it is
received reverts to the original timeout value, not the value you set
with the ChangeMessageVisibility action.
```