### PR TITLE
GLOB-3763 - properly set visibility default

### DIFF
--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -41,6 +41,9 @@ class ConsumerDaemon(Daemon):
             pubsub_message_codecs=dict(
                 mappings=self.schema_mappings,
             ),
+            sqs_consumer=dict(
+                visibility_timeout_seconds=None,
+            ),
         )
         if self.handler_mappings:
             dct.update(
@@ -49,11 +52,8 @@ class ConsumerDaemon(Daemon):
                 ),
             )
         if self.args.sqs_queue_url:
-            dct.update(
-                sqs_consumer=dict(
-                    sqs_queue_url=self.args.sqs_queue_url,
-                ),
-            )
+            dct.sqs_consumer.sqs_queue_url = self.args.sqs_queue_url
+
         return dct
 
     @property


### PR DESCRIPTION
Why:

* Following on from
  https://github.com/globality-corp/microcosm-pubsub/pull/22 there was a
  missing default for visibilty_timeout_seconds, which would make the
  change non-backwards compatible.

This change addresses the need by:

* adds `visibilty_timeout_seconds` to the defaults for the daemon

https://globality.atlassian.net/browse/GLOB-3763