### PR TITLE
cast visibility timeout as int of not None

### DIFF
--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -85,6 +85,9 @@ def configure_sqs_consumer(graph):
     wait_seconds = graph.config.sqs_consumer.wait_seconds
     visibility_timeout_seconds = graph.config.sqs_consumer.visibility_timeout_seconds
 
+    if visibility_timeout_seconds:
+        visibility_timeout_seconds = int(visibility_timeout_seconds)
+
     if graph.metadata.testing:
         from mock import MagicMock
         sqs_client = MagicMock()


### PR DESCRIPTION
There is an error if visibility_timeout_seconds is a string.  Cast value to int if not None.