### PR TITLE
Enable fluent decorators for registering PubSub schemas and handlers.

### DIFF
--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -2,11 +2,9 @@
 Message encoding and decoding.
 
 """
-from collections import defaultdict
 from json import dumps, loads
 
 from marshmallow import fields, Schema, ValidationError
-from microcosm.api import defaults
 
 
 DEFAULT_MEDIA_TYPE = "application/vnd.globality.pubsub.default"
@@ -89,27 +87,3 @@ class PubSubMessageCodec(object):
         self.schema.validate(dct)
         decoded = self.schema.dump(dct)
         return decoded.data
-
-
-@defaults(
-    default=None,
-    strict=True,
-    mappings=dict(),
-)
-def configure_pubsub_message_codecs(graph):
-    """
-    Configure a mapping from message types to codecs.
-
-    """
-    default_schema_cls = graph.config.pubsub_message_codecs.default
-    strict = graph.config.pubsub_message_codecs.strict
-
-    if default_schema_cls:
-        message_codecs = defaultdict(lambda: PubSubMessageCodec(default_schema_cls(strict=strict)))
-    else:
-        message_codecs = dict()
-
-    for key, schema_cls in graph.config.pubsub_message_codecs.mappings.items():
-        message_codecs[key] = PubSubMessageCodec(schema_cls(strict=strict))
-
-    return message_codecs

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -66,7 +66,7 @@ class SQSConsumer(object):
             self.sqs_client.change_message_visibility(
                 QueueUrl=self.sqs_queue_url,
                 ReceiptHandle=message.receipt_handle,
-                # we can only set integer or float timeouts
+                # we can only set integer timeouts
                 VisibilityTimeout=int(timeout),
             )
 
@@ -76,6 +76,8 @@ class SQSConsumer(object):
     limit=10,
     # SQS will only return a few messages at time unless long polling is enabled (>0)
     wait_seconds=1,
+    # By default, don't change message visibility on nack
+    visibility_timeout_seconds=None,
 )
 def configure_sqs_consumer(graph):
     """

--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -1,7 +1,13 @@
+"""
+Message context.
+
+"""
+
+
 def sqs_message_context(message):
-    #  NB This is the simplest possible idea for associated context with a handler funcion.
-    #  In the future it would make sense to make this function configurable and
-    #  add some parameters to control additional behavior.
+    # NB This is the simplest possible idea for associated context with a handler funcion.
+    # In the future it would make sense to make this function configurable and
+    # add some parameters to control additional behavior.
     return message.get("opaque_data", dict())
 
 

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -2,8 +2,6 @@
 Consume Daemon main.
 
 """
-from abc import abstractproperty
-
 import microcosm.opaque  # noqa
 from microcosm_daemon.api import SleepNow
 from microcosm_daemon.daemon import Daemon
@@ -16,34 +14,35 @@ class ConsumerDaemon(Daemon):
         parser.add_argument("--sqs-queue-url")
         return parser
 
-    @abstractproperty
     def schema_mappings(self):
         """
         Define the PubSub message media-type to schema mappings.
 
         """
-        pass
+        return dict()
+
+    def create_object_graph(self, args):
+        graph = super(ConsumerDaemon, self).create_object_graph(args)
+        for media_type, schema_cls in self.schema_mappings.items():
+            self.graph.pubsub_message_schema_registry.register(media_type, schema_cls)
+        return graph
 
     @property
     def defaults(self):
-        dct = dict(
-            pubsub_message_codecs=dict(
-                mappings=self.schema_mappings,
-            ),
+        if not self.args.sqs_queue_url:
+            return dict()
+
+        return dict(
             sqs_consumer=dict(
-                visibility_timeout_seconds=None,
+                sqs_queue_url=self.args.sqs_queue_url,
             ),
         )
-        if self.args.sqs_queue_url:
-            dct['sqs_consumer']['sqs_queue_url'] = self.args.sqs_queue_url
-
-        return dct
 
     @property
     def components(self):
         return super(ConsumerDaemon, self).components + [
             "opaque",
-            "pubsub_message_codecs",
+            "pubsub_message_schema_registry",
             "sqs_consumer",
             "sqs_message_dispatcher",
         ]

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -43,6 +43,7 @@ class ConsumerDaemon(Daemon):
         return super(ConsumerDaemon, self).components + [
             "opaque",
             "pubsub_message_schema_registry",
+            "sqs_message_handler_registry",
             "sqs_consumer",
             "sqs_message_dispatcher",
         ]

--- a/microcosm_pubsub/decorators.py
+++ b/microcosm_pubsub/decorators.py
@@ -1,0 +1,31 @@
+"""
+Fluent decorators for resources and handlers.
+
+"""
+from microcosm_pubsub.registry import (
+    register_handler,
+    register_schema,
+)
+
+
+def handles(schema_cls):
+    """
+    Register a handler, tying it to a specific resource.
+
+    Also registers its schema.
+
+    """
+    def decorator(func):
+        register_schema(schema_cls)
+        register_handler(schema_cls, func)
+        return func
+    return decorator
+
+
+def schema(schema_cls):
+    """
+    Register a schema.
+
+    """
+    register_schema(schema_cls)
+    return schema_cls

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -66,7 +66,7 @@ class SQSMessageDispatcher(object):
 
         with self.opaque.initialize(self.sqs_message_context, message):
             try:
-                sqs_message_handler = self.sqs_message_handler_registry.find(media_type)
+                sqs_message_handler = self.sqs_message_handler_registry[media_type]
             except KeyError:
                 # no handlers
                 self.logger.debug("Skipping message with no registered handler: {}".format(media_type))

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -65,16 +65,18 @@ class SQSMessageDispatcher(object):
             return False
 
         with self.opaque.initialize(self.sqs_message_context, message):
-            for sqs_message_handler in self.sqs_message_handler_registry.iterate(media_type):
+            try:
+                sqs_message_handler = self.sqs_message_handler_registry.find(media_type)
+            except KeyError:
+                # no handlers
+                return False
+            else:
                 handler_with_context = context_logger(
                     self.sqs_message_context,
                     sqs_message_handler,
                     parent=sqs_message_handler,
                 )
                 return handler_with_context(message)
-            else:
-                # no handlers
-                return False
 
 
 def configure(graph):

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -61,7 +61,7 @@ class SQSMessageDispatcher(object):
 
         """
         if message is None:
-            logger.debug("Skipping message with unparsed type: {}".format(media_type))
+            self.logger.debug("Skipping message with unparsed type: {}".format(media_type))
             return False
 
         with self.opaque.initialize(self.sqs_message_context, message):
@@ -69,6 +69,7 @@ class SQSMessageDispatcher(object):
                 sqs_message_handler = self.sqs_message_handler_registry.find(media_type)
             except KeyError:
                 # no handlers
+                self.logger.debug("Skipping message with no registered handler: {}".format(media_type))
                 return False
             else:
                 handler_with_context = context_logger(

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -3,30 +3,34 @@ Process batches of messages.
 
 """
 from collections import namedtuple
-from logging import getLogger
 
-from microcosm.api import defaults
 from microcosm.errors import NotBoundError
-from microcosm_logging.decorators import context_logger
+from microcosm_logging.decorators import context_logger, logger
 from microcosm_pubsub.errors import Nack
 
 
 DispatchResult = namedtuple("DispatchResult", ["message_count", "error_count", "ignore_count"])
 
 
-logger = getLogger("pubsub.sink")
-
-
+@logger
 class SQSMessageDispatcher(object):
     """
     Dispatch batches of SQSMessages to handler functions.
 
     """
-    def __init__(self, opaque, sqs_consumer, sqs_message_handlers, sqs_message_context):
-        self.sqs_consumer = sqs_consumer
-        self.sqs_message_handlers = sqs_message_handlers
-        self.sqs_message_context = sqs_message_context
-        self.opaque = opaque
+    def __init__(self, graph):
+        self.opaque = graph.opaque
+        self.sqs_consumer = graph.sqs_consumer
+        self.sqs_message_context = self._find_sqs_message_context(graph)
+        self.sqs_message_handler_registry = graph.sqs_message_handler_registry
+
+    def _find_sqs_message_context(self, graph):
+        try:
+            return graph.sqs_message_context
+        except NotBoundError:
+            def context(message):
+                return dict()
+            return context
 
     def handle_batch(self):
         """
@@ -42,7 +46,7 @@ class SQSMessageDispatcher(object):
                     if not self.handle_message(message.media_type, message.content):
                         ignore_count += 1
             except Exception as error:
-                logger.info(
+                self.logger.info(
                     "Error handling SQS message.",
                     exc_info=not isinstance(error, Nack),
                     extra=self.sqs_message_context(message.content)
@@ -59,53 +63,23 @@ class SQSMessageDispatcher(object):
         if message is None:
             logger.debug("Skipping message with unparsed type: {}".format(media_type))
             return False
-        sqs_message_handler = self.sqs_message_handlers.get(media_type)
-        if sqs_message_handler is None:
-            logger.debug("Skipping message with unsupported type: {}".format(media_type))
-            return False
 
-        handler_with_context = context_logger(
-            self.sqs_message_context,
-            sqs_message_handler,
-            parent=sqs_message_handler,
-        )
         with self.opaque.initialize(self.sqs_message_context, message):
-            return handler_with_context(message)
+            for sqs_message_handler in self.sqs_message_handler_registry.iterate(media_type):
+                handler_with_context = context_logger(
+                    self.sqs_message_context,
+                    sqs_message_handler,
+                    parent=sqs_message_handler,
+                )
+                return handler_with_context(message)
+            else:
+                # no handlers
+                return False
 
 
-@defaults(
-    mappings=dict(),
-)
-def configure_sqs_message_dispatcher(graph):
-    """
-    Configure dispatching of SQS messages.
-
-    Requires a dictionary mapping from the message media type to a handler function; unmapped
-    messages will be ignored. This dictionary can either be defined using the `sqs_message_dispatcher.mappings`
-    configuration key (which is convenient for simple handlers) or, more likely, via a separate
-    `sqs_message_handlers` graph component (which is convenient of the handlers need other component collaborators).
-    """
-    try:
-        sqs_message_handlers = graph.sqs_message_handlers
-    except NotBoundError:
-        sqs_message_handlers = graph.config.sqs_message_dispatcher.mappings
-
-    try:
-        sqs_message_context = graph.sqs_message_context
-    except NotBoundError:
-        def context(message):
-            return dict()
-        sqs_message_context = context
-
+def configure(graph):
     if graph.metadata.testing:
         from mock import MagicMock
-        opaque = MagicMock(bind=MagicMock())
-    else:
-        opaque = graph.opaque
+        graph.opaque = MagicMock(bind=MagicMock())
 
-    return SQSMessageDispatcher(
-        opaque=opaque,
-        sqs_consumer=graph.sqs_consumer,
-        sqs_message_handlers=sqs_message_handlers,
-        sqs_message_context=sqs_message_context,
-    )
+    return SQSMessageDispatcher(graph)

--- a/microcosm_pubsub/envelope.py
+++ b/microcosm_pubsub/envelope.py
@@ -24,7 +24,6 @@ class SQSEnvelope(object):
     __metaclass__ = ABCMeta
 
     def __init__(self, graph):
-        self.pubsub_message_codecs = graph.pubsub_message_codecs
         self.validate_md5 = graph.config.sqs_envelope.validate_md5
 
     def parse_raw_message(self, consumer, raw_message):
@@ -95,6 +94,7 @@ class CodecSQSEnvelope(SQSEnvelope):
     def __init__(self, graph):
         super(CodecSQSEnvelope, self).__init__(graph)
         self.media_type_codec = PubSubMessageCodec(MediaTypeSchema())
+        self.pubsub_message_schema_registry = graph.pubsub_message_schema_registry
 
     def parse_media_type_and_content(self, message):
         """
@@ -104,7 +104,7 @@ class CodecSQSEnvelope(SQSEnvelope):
         base_message = self.media_type_codec.decode(message)
         media_type = base_message["mediaType"]
         try:
-            content = self.pubsub_message_codecs[media_type].decode(message)
+            content = self.pubsub_message_schema_registry[media_type].decode(message)
         except KeyError:
             return media_type, None
         else:

--- a/microcosm_pubsub/fields.py
+++ b/microcosm_pubsub/fields.py
@@ -1,8 +1,10 @@
 """
 Custom fields.
+
 """
-from marshmallow.fields import Field, ValidationError
 from uuid import UUID
+
+from marshmallow.fields import Field, ValidationError
 
 
 class UUIDField(Field):

--- a/microcosm_pubsub/handlers.py
+++ b/microcosm_pubsub/handlers.py
@@ -1,0 +1,109 @@
+"""
+Handler base classes.
+
+"""
+from abc import ABCMeta
+from inflection import humanize
+
+from requests import get
+
+
+class URIHandler(object):
+    """
+    Base handler for URI-driven events.
+
+    As a general rule, we want PubSub events to convey the URI of a resource that was created
+    (because resources are ideally immutable state). In this case, we want asynchronous workers
+    to query the existing URI to get more information (and to handle race conditions where the
+    message was delivered before the resource was committed.)
+
+    There are five expected outcomes for this handler:
+      - Raising an error (e.g. a bug)
+      - Skipping the handlers (because the pubsub message carried enough information to bypass processing)
+      - Handling the message after fetching the resource by URI
+      - Ignore the message after fetching the resource by URI
+      - Raising a nack (e.g. because the resource was not committed yet)
+
+    The middle three cases are all handled here with the expectation that we produce *one* INFO-level
+    log per message processed (unless an error/nack is raised).
+
+    """
+    __metaclass__ = ABCMeta
+
+    @property
+    def name(self):
+        return humanize(self.__class__.__name__)
+
+    def __call__(self, message):
+        uri = message["uri"]
+        self.on_call(message, uri)
+
+        skip_reason = self.get_reason_to_skip(message, uri)
+        if skip_reason is not None:
+            self.on_skip(message, uri, skip_reason)
+            return False
+
+        resource = self.get_resource(uri=uri)
+
+        if self.handle(message, uri, resource):
+            self.on_handle(message, uri, resource)
+            return True
+        else:
+            self.on_ignore(message, uri, resource)
+            return False
+
+    def on_call(self, message, uri):
+        self.logger.debug(
+            "Starting {handler}",
+            extra=dict(
+                handler=self.name,
+                uri=uri,
+            ),
+        )
+
+    def on_skip(self, message, uri, reason):
+        self.logger.info(
+            "Skipping {handler} because {reason}",
+            extra=dict(
+                handler=self.name,
+                reason=reason,
+                uri=uri,
+            ),
+        )
+
+    def on_handle(self, message, uri, resource):
+        self.logger.info(
+            "Handled {handler}",
+            extra=dict(
+                handler=self.name,
+                uri=uri,
+            ),
+        )
+
+    def on_ignore(self, message, uri, resource):
+        self.logger.info(
+            "Ignored {handler}",
+            extra=dict(
+                handler=self.name,
+                uri=uri,
+            ),
+        )
+
+    def get_reason_to_skip(self, message, uri):
+        """
+        Some messages carry enough context that we can avoid resolving the URI entirely.
+
+        """
+        return None
+
+    def get_resource(self, uri):
+        """
+        Mock-friendly URI getter.
+
+        """
+        response = get(uri)
+        response.raise_for_status()
+        return response.json()
+
+    def handle(self, message, resource):
+        return True

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -16,9 +16,9 @@ class SNSProducer(object):
     Produces messages to SNS topics.
 
     """
-    def __init__(self, opaque, pubsub_message_codecs, sns_client, sns_topic_arns):
+    def __init__(self, opaque, pubsub_message_schema_registry, sns_client, sns_topic_arns):
         self.opaque = opaque
-        self.pubsub_message_codecs = pubsub_message_codecs
+        self.pubsub_message_schema_registry = pubsub_message_schema_registry
         self.sns_client = sns_client
         self.sns_topic_arns = sns_topic_arns
 
@@ -36,7 +36,7 @@ class SNSProducer(object):
         if self.opaque is not None:
             kwargs.setdefault('opaque_data', self.opaque.as_dict())
         topic_arn = self.choose_topic_arn(media_type)
-        message = self.pubsub_message_codecs[media_type].encode(dct, **kwargs)
+        message = self.pubsub_message_schema_registry[media_type].encode(dct, **kwargs)
         return message, topic_arn
 
     def publish_message(self, message, topic_arn):
@@ -131,7 +131,7 @@ def configure_sns_producer(graph):
 
     return SNSProducer(
         opaque=opaque,
-        pubsub_message_codecs=graph.pubsub_message_codecs,
+        pubsub_message_schema_registry=graph.pubsub_message_schema_registry,
         sns_client=sns_client,
         sns_topic_arns=graph.sns_topic_arns,
     )

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -78,10 +78,6 @@ class PubSubMessageSchemaRegistry(Registry):
     def legacy_binding_key(self):
         return "pubsub_message_codecs"
 
-    @property
-    def allows_multiple(self):
-        return False
-
     def __getitem__(self, media_type):
         """
         Create a codec or raise KeyError.
@@ -103,9 +99,6 @@ class SQSMessageHandlerRegistry(Registry):
     @property
     def legacy_binding_key(self):
         return "sqs_message_handlers"
-
-    def allows_multiple(self):
-        return True
 
 
 @defaults(

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -42,9 +42,9 @@ class Registry(object):
     @classmethod
     def register(cls, media_type, value):
         """
-        Register a valuex for a media type.
+        Register a value for a media type.
 
-        It is an error to register the same value multiple times.
+        It is an error to register more than one value for the same media type.
 
         """
         existing_value = cls.MAPPINGS.get(media_type)

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -1,0 +1,139 @@
+"""
+Registry of SQS message handlers.
+
+"""
+from abc import ABCMeta, abstractproperty
+from microcosm.api import defaults
+from microcosm.errors import NotBoundError
+from microcosm_logging.decorators import logger
+
+from microcosm_pubsub.codecs import PubSubMessageCodec
+
+
+class AlreadyRegisteredError(Exception):
+    pass
+
+
+class Registry(object):
+    """
+    A decorator-friendly registry of per-media type objects.
+
+    Supports static configuration from binding keys and explicit registration from decorators
+    (using a singleton).
+
+    """
+    __metaclass__ = ABCMeta
+
+    def __init__(self, graph):
+        """
+        Create registry, auto-registering items found using the legacy graph binding key.
+
+        """
+        try:
+            for media_type, value in getattr(graph, self.legacy_binding_key).items():
+                self.register(media_type, value)
+        except NotBoundError:
+            pass
+
+    @abstractproperty
+    def legacy_binding_key(self):
+        pass
+
+    @classmethod
+    def register(cls, media_type, value):
+        """
+        Register a valuex for a media type.
+
+        It is an error to register the same value multiple times.
+
+        """
+        existing_value = cls.MAPPINGS.get(media_type)
+        if existing_value:
+            if value == existing_value:
+                return
+            raise AlreadyRegisteredError("A mapping already exists  media type: {}".format(
+                media_type,
+            ))
+        cls.MAPPINGS[media_type] = value
+
+    @classmethod
+    def find(cls, media_type):
+        return cls.MAPPINGS[media_type]
+
+
+@logger
+class PubSubMessageSchemaRegistry(Registry):
+    """
+    Keeps track of available message schemas.
+
+    """
+    # singleton registry
+    MAPPINGS = dict()
+
+    def __init__(self, graph):
+        super(PubSubMessageSchemaRegistry, self).__init__(graph)
+        self.strict = graph.config.pubsub_message_schema_registry.strict
+
+    @property
+    def legacy_binding_key(self):
+        return "pubsub_message_codecs"
+
+    @property
+    def allows_multiple(self):
+        return False
+
+    def __getitem__(self, media_type):
+        """
+        Create a codec or raise KeyError.
+
+        """
+        schema_cls = self.__class__.find(media_type)
+        return PubSubMessageCodec(schema_cls(strict=self.strict))
+
+
+@logger
+class SQSMessageHandlerRegistry(Registry):
+    """
+    Keeps track of available handlers.
+
+    """
+    # singleton registry
+    MAPPINGS = dict()
+
+    @property
+    def legacy_binding_key(self):
+        return "sqs_message_handlers"
+
+    def allows_multiple(self):
+        return True
+
+    def iterate(self, media_type):
+        """
+        Iterate through available values for the given media type.
+
+        """
+        value = self.__class__.find(media_type)
+        if not value:
+            self.logger.debug("No mapping found for media type: {}".format(media_type))
+            return
+
+        yield value
+
+
+@defaults(
+    strict=True,
+)
+def configure_schema_registry(graph):
+    return PubSubMessageSchemaRegistry(graph)
+
+
+def configure_handler_registry(graph):
+    return SQSMessageHandlerRegistry(graph)
+
+
+def register_schema(schema_cls):
+    PubSubMessageSchemaRegistry.register(schema_cls.MEDIA_TYPE, schema_cls)
+
+
+def register_handler(schema_cls, handler):
+    SQSMessageHandlerRegistry.register(schema_cls.MEDIA_TYPE, handler)

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -107,18 +107,6 @@ class SQSMessageHandlerRegistry(Registry):
     def allows_multiple(self):
         return True
 
-    def iterate(self, media_type):
-        """
-        Iterate through available values for the given media type.
-
-        """
-        value = self.__class__.find(media_type)
-        if not value:
-            self.logger.debug("No mapping found for media type: {}".format(media_type))
-            return
-
-        yield value
-
 
 @defaults(
     strict=True,

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -3,6 +3,8 @@ Registry of SQS message handlers.
 
 """
 from abc import ABCMeta, abstractproperty
+from inspect import isclass
+
 from microcosm.api import defaults
 from microcosm.errors import NotBoundError
 from microcosm_logging.decorators import logger
@@ -29,10 +31,19 @@ class Registry(object):
         Create registry, auto-registering items found using the legacy graph binding key.
 
         """
+        self.graph = graph
+
+        # legacy graph handling
         try:
             for media_type, value in getattr(graph, self.legacy_binding_key).items():
                 self.register(media_type, value)
         except NotBoundError:
+            pass
+        # legacy config handling
+        try:
+            for media_type, value in getattr(graph.config, self.legacy_binding_key).get("mappings").items():
+                self.register(media_type, value)
+        except AttributeError:
             pass
 
     @abstractproperty
@@ -57,8 +68,8 @@ class Registry(object):
         cls.MAPPINGS[media_type] = value
 
     @classmethod
-    def find(cls, media_type):
-        return cls.MAPPINGS[media_type]
+    def keys(cls):
+        return cls.MAPPINGS.keys()
 
 
 @logger
@@ -83,7 +94,7 @@ class PubSubMessageSchemaRegistry(Registry):
         Create a codec or raise KeyError.
 
         """
-        schema_cls = self.__class__.find(media_type)
+        schema_cls = self.__class__.MAPPINGS[media_type]
         return PubSubMessageCodec(schema_cls(strict=self.strict))
 
 
@@ -100,6 +111,17 @@ class SQSMessageHandlerRegistry(Registry):
     def legacy_binding_key(self):
         return "sqs_message_handlers"
 
+    def __getitem__(self, media_type):
+        """
+        Create a handler or raise KeyError.
+
+        """
+        handler = self.__class__.MAPPINGS[media_type]
+        if isclass(handler):
+            return handler(self.graph)
+        else:
+            return handler
+
 
 @defaults(
     strict=True,
@@ -112,9 +134,17 @@ def configure_handler_registry(graph):
     return SQSMessageHandlerRegistry(graph)
 
 
+def media_type_for(schema_cls):
+    if hasattr(schema_cls, "MEDIA_TYPE"):
+        return schema_cls.MEDIA_TYPE
+    if hasattr(schema_cls, "infer_media_type"):
+        return schema_cls.infer_media_type()
+    raise Exception("Cannot infer media type for schema class: {}".format(schema_cls))
+
+
 def register_schema(schema_cls):
-    PubSubMessageSchemaRegistry.register(schema_cls.MEDIA_TYPE, schema_cls)
+    PubSubMessageSchemaRegistry.register(media_type_for(schema_cls), schema_cls)
 
 
 def register_handler(schema_cls, handler):
-    SQSMessageHandlerRegistry.register(schema_cls.MEDIA_TYPE, handler)
+    SQSMessageHandlerRegistry.register(media_type_for(schema_cls), handler)

--- a/microcosm_pubsub/tests/fixtures.py
+++ b/microcosm_pubsub/tests/fixtures.py
@@ -3,6 +3,7 @@ Test fixtures.
 
 """
 from marshmallow import fields
+from microcosm.api import binding
 
 from microcosm_pubsub.codecs import PubSubMessageSchema
 
@@ -20,3 +21,21 @@ class FooSchema(PubSubMessageSchema):
 
     def deserialize_media_type(self, obj):
         return FooSchema.MEDIA_TYPE
+
+
+def foo_handler(message):
+    return True
+
+
+@binding("pubsub_message_codecs")
+def configure_pubsub_message_codecs(graph):
+    return {
+        FooSchema.MEDIA_TYPE: FooSchema,
+    }
+
+
+@binding("sqs_message_handlers")
+def configure_sqs_message_handlers(graph):
+    return {
+        FooSchema.MEDIA_TYPE: foo_handler,
+    }

--- a/microcosm_pubsub/tests/test_decorators.py
+++ b/microcosm_pubsub/tests/test_decorators.py
@@ -39,6 +39,6 @@ class TestDecorators(object):
 
     def test_handles_decorators(self):
         assert_that(
-            self.graph.sqs_message_handler_registry.find(TestSchema.MEDIA_TYPE),
+            self.graph.sqs_message_handler_registry[TestSchema.MEDIA_TYPE],
             is_(equal_to(noop_handler)),
         )

--- a/microcosm_pubsub/tests/test_decorators.py
+++ b/microcosm_pubsub/tests/test_decorators.py
@@ -4,7 +4,7 @@ Decorator tests.
 """
 from hamcrest import (
     assert_that,
-    contains,
+    equal_to,
     instance_of,
     is_,
 )
@@ -39,6 +39,6 @@ class TestDecorators(object):
 
     def test_handles_decorators(self):
         assert_that(
-            list(self.graph.sqs_message_handler_registry.iterate(TestSchema.MEDIA_TYPE)),
-            contains(noop_handler)
+            self.graph.sqs_message_handler_registry.find(TestSchema.MEDIA_TYPE),
+            is_(equal_to(noop_handler)),
         )

--- a/microcosm_pubsub/tests/test_decorators.py
+++ b/microcosm_pubsub/tests/test_decorators.py
@@ -1,0 +1,44 @@
+"""
+Decorator tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    contains,
+    instance_of,
+    is_,
+)
+from marshmallow import fields, Schema
+from microcosm.api import create_object_graph
+
+from microcosm_pubsub.decorators import handles, schema
+
+
+@schema
+class TestSchema(Schema):
+    MEDIA_TYPE = "test"
+
+    test = fields.String()
+
+
+@handles(TestSchema)
+def noop_handler(message):
+    return True
+
+
+class TestDecorators(object):
+
+    def setup(self):
+        self.graph = create_object_graph("test")
+
+    def test_schema_decorators(self):
+        assert_that(
+            self.graph.pubsub_message_schema_registry[TestSchema.MEDIA_TYPE].schema,
+            is_(instance_of(TestSchema)),
+        )
+
+    def test_handles_decorators(self):
+        assert_that(
+            list(self.graph.sqs_message_handler_registry.iterate(TestSchema.MEDIA_TYPE)),
+            contains(noop_handler)
+        )

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -12,6 +12,7 @@ from microcosm.registry import Registry
 from mock import Mock
 
 from microcosm_pubsub.tests.fixtures import (
+    foo_handler,
     FOO_QUEUE_URL,
     FooSchema,
 )
@@ -38,7 +39,7 @@ def test_handle():
     @binding("sqs_message_handlers", graph._registry)
     def configure_message_handlers(graph):
         return {
-            FooSchema.MEDIA_TYPE: Mock(return_value=True),
+            FooSchema.MEDIA_TYPE: foo_handler,
         }
 
     graph.use(
@@ -75,7 +76,7 @@ def test_handle_with_no_context():
     @binding("sqs_message_handlers", graph._registry)
     def configure_message_handlers(graph):
         return {
-            FooSchema.MEDIA_TYPE: Mock(return_value=True),
+            FooSchema.MEDIA_TYPE: foo_handler,
         }
     graph.use(
         'sqs_message_handlers',

--- a/microcosm_pubsub/tests/test_registry.py
+++ b/microcosm_pubsub/tests/test_registry.py
@@ -1,0 +1,78 @@
+"""
+Test registry.
+
+"""
+from hamcrest import (
+    assert_that,
+    calling,
+    empty,
+    has_length,
+    is_,
+    raises,
+)
+from microcosm.api import create_object_graph
+
+from microcosm_pubsub.codecs import DEFAULT_MEDIA_TYPE, PubSubMessageSchema
+import microcosm_pubsub.registry  # noqa: F401
+from microcosm_pubsub.tests.fixtures import foo_handler, FooSchema
+
+
+def another_handler(message):
+    return True
+
+
+class AnotherSchema(PubSubMessageSchema):
+    MEDIA_TYPE = "application/vnd.globality.pubsub.test"
+
+
+class FooPubSubMessageCodecRegistry(object):
+
+    def setup(self):
+        self.graph = create_object_graph("test")
+        self.registry = self.graph.pubsub_message_schema_registry
+
+    def test_iterate_not_found(self):
+        schemas = list(self.registry.iterate(DEFAULT_MEDIA_TYPE))
+        assert_that(schemas, is_(empty()))
+
+    def test_iterate_found(self):
+        schemas = list(self.registry.iterate(FooSchema.MEDIA_TYPE))
+        assert_that(schemas, has_length(1))
+
+    def test_iterate_multiple_not_allowed(self):
+        assert_that(
+            calling(self.registry.register).with_args(FooSchema.MEDIA_TYPE, AnotherSchema),
+            raises(Exception),
+        )
+
+    def test_iterate_duplicate(self):
+        assert_that(
+            calling(self.registry.register).with_args(FooSchema.MEDIA_TYPE, FooSchema),
+            raises(Exception),
+        )
+
+
+class FooSQSMessageHandlerRegistry(object):
+
+    def setup(self):
+        self.graph = create_object_graph("test")
+        self.registry = self.graph.sqs_message_handler_registry
+
+    def test_iterate_not_found(self):
+        handlers = list(self.registry.iterate(DEFAULT_MEDIA_TYPE))
+        assert_that(handlers, is_(empty()))
+
+    def test_iterate_found(self):
+        handlers = list(self.registry.iterate(FooSchema.MEDIA_TYPE))
+        assert_that(handlers, has_length(1))
+
+    def test_iterate_multiple(self):
+        self.registry.register(FooSchema.MEDIA_TYPE, another_handler)
+        handlers = list(self.registry.iterate(FooSchema.MEDIA_TYPE))
+        assert_that(handlers, has_length(2))
+
+    def test_iterate_duplicate(self):
+        assert_that(
+            calling(self.registry.register).with_args(FooSchema.MEDIA_TYPE, foo_handler),
+            raises(Exception),
+        )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "boto3>=1.3.0",
         "marshmallow>=2.6.1",
         "microcosm>=0.12.0",
-        "microcosm-daemon>=0.2.0",
+        "microcosm-daemon>=0.8.0",
     ],
     setup_requires=[
         "nose>=1.3.6",

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,11 @@ setup(
     entry_points={
         "microcosm.factories": [
             "sqs_message_context = microcosm_pubsub.context:configure_sqs_message_context",
-            "pubsub_message_codecs = microcosm_pubsub.codecs:configure_pubsub_message_codecs",
+            "pubsub_message_schema_registry = microcosm_pubsub.registry:configure_schema_registry",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",
             "sqs_envelope = microcosm_pubsub.envelope:configure_sqs_envelope",
-            "sqs_message_dispatcher = microcosm_pubsub.dispatcher:configure_sqs_message_dispatcher",
+            "sqs_message_dispatcher = microcosm_pubsub.dispatcher:configure",
+            "sqs_message_handler_registry = microcosm_pubsub.registry:configure_handler_registry",
             "sns_producer = microcosm_pubsub.producer:configure_sns_producer",
             "sns_topic_arns = microcosm_pubsub.producer:configure_sns_topic_arns",
         ]


### PR DESCRIPTION
This is best demonstrated by example:

    @schema
    class MySchema(PubSubMessageSchema):
        my_field = fields.String()

    @binding("my_handler")
    @handles(MySchema)
    class MyHandler(object):

        def __init__(self, graph):
            self.collaborator = graph.collaborator

        def __call__(self, message):
            self.collaborator.do_something(message)
            return True

The underlying change involves moving the schema and handler mappings into a centralized,
singleton registry. This is a small loss in terms of object graph purity -- these mappings
are stored in singletons, not the object graph because it's rather inconvenient to enforce
that the graph exists at the point in time that these types are declared -- but the benefit
is a great deal more clarity to what was a frequent source of usage errors.

The legacy registry mechanism (namely, dictionaries bound to the graph) still exists, but
is implemented by loading these dictionaries into the registry when the graph binds the
registries. This behavior still needs some testing in anger.