### PR TITLE
Convention-driven pubsub messaging.

### DIFF
--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -7,7 +7,7 @@ from json import dumps, loads
 from marshmallow import fields, Schema, ValidationError
 
 
-DEFAULT_MEDIA_TYPE = "application/vnd.globality.pubsub.default"
+DEFAULT_MEDIA_TYPE = "application/json"
 
 
 class PubSubMessageSchema(Schema):
@@ -24,7 +24,10 @@ class PubSubMessageSchema(Schema):
         # need to set missing to non-None or marshmallow won't call the deserialize function
         missing=DEFAULT_MEDIA_TYPE,
     )
-    opaque_data = fields.Dict(required=False)
+    opaque_data = fields.Dict(
+        attribute="opaqueData",
+        required=False,
+    )
 
     def serialize_media_type(self, message):
         """

--- a/microcosm_pubsub/conventions.py
+++ b/microcosm_pubsub/conventions.py
@@ -1,0 +1,98 @@
+"""
+Convention-driven pubsub.
+
+"""
+from enum import Enum, unique
+
+from inflection import underscore
+from marshmallow import fields
+
+from microcosm_pubsub.codecs import PubSubMessageSchema
+
+
+@unique
+class LifecycleChange(Enum):
+    """
+    CRUD lifecycle changes that may be announced via pubsub.
+
+    Note that `Changed` is strongly discouraged; use immutable resources instead.
+
+    """
+    Changed = u"changed"
+    Created = u"created"
+    Deleted = u"deleted"
+
+    def matches(self, media_type):
+        return self.value in media_type.split(".")
+
+
+def make_media_type(resource, lifecycle_change=None, organization=None, public=False):
+    """
+    Generate a canonical media type for a message that announces a lifecycle change to a resource.
+
+    :param resource: the resource (name)
+    :param lifecycle_change: the change that happened to the resource
+    :param organization: the vendor organization to which this resource belongs
+    :param public: whether the resource is meant for public/external consumption
+
+    """
+    if lifecycle_change is None:
+        lifecycle_change = LifecycleChange.Created
+    if organization is None:
+        organization = "globality"
+
+    return "application/vnd.{}.{}.{}.{}".format(
+        # use a vendor specific media type
+        organization,
+        # differentiate messages sent over a pubsub channel from other messages
+        "pubsub" if public else "pubsub._",
+        # qualify the message with the kind of lifecycle change
+        lifecycle_change.value,
+        # specify the resource name
+        underscore(resource),
+    )
+
+
+class URIMessageSchema(PubSubMessageSchema):
+    """
+    Define a baseline message schema that points to (the URI of) a resource that experienced a lifecycle change.
+
+    By convention, pubsub messages should be *references* to something that happened within some other
+    source-of-truth (e.g. a CRUD microservice). Because there are inherent race conditions between publishing
+    a message and commit a persistent transaction, message consumers are expected to call back to source-of-truth
+    (e.g. via HTTP) and fetch the current resource value. In the event that message has not been committed yet,
+    the consumer can retry a few times before giving up (e.g. via SQS dead-lettering).
+
+    """
+    def __init__(self, media_type, **kwargs):
+        super(PubSubMessageSchema, self).__init__(**kwargs)
+        self.MEDIA_TYPE = media_type
+
+    uri = fields.String(required=True)
+
+    def deserialize_media_type(self, obj):
+        return self.MEDIA_TYPE
+
+
+def changed(resource, **kwargs):
+    """
+    Fluent wrapper around message publishing for convention-driven schemas.
+
+    """
+    return make_media_type(resource, lifecycle_change=LifecycleChange.Changed, **kwargs)
+
+
+def created(resource, **kwargs):
+    """
+    Fluent wrapper around message publishing for convention-driven schemas.
+
+    """
+    return make_media_type(resource, lifecycle_change=LifecycleChange.Created, **kwargs)
+
+
+def deleted(resource, **kwargs):
+    """
+    Fluent wrapper around message publishing for convention-driven schemas.
+
+    """
+    return make_media_type(resource, lifecycle_change=LifecycleChange.Deleted, **kwargs)

--- a/microcosm_pubsub/conventions.py
+++ b/microcosm_pubsub/conventions.py
@@ -3,6 +3,8 @@ Convention-driven pubsub.
 
 """
 from enum import Enum, unique
+from inspect import isclass
+from six import string_types
 
 from inflection import underscore
 from marshmallow import fields
@@ -24,6 +26,24 @@ class LifecycleChange(Enum):
 
     def matches(self, media_type):
         return self.value in media_type.split(".")
+
+
+def name_for(obj):
+    """
+    Get a name for something.
+
+    Allows overriding of default names using the `__alias__` attribute.
+
+    """
+    if isinstance(obj, string_types):
+        return underscore(obj)
+
+    cls = obj if isclass(obj) else obj.__class__
+
+    if hasattr(cls, "__alias__"):
+        return underscore(cls.__alias__)
+    else:
+        return underscore(cls.__name__)
 
 
 def make_media_type(resource, lifecycle_change=None, organization=None, public=False):
@@ -49,7 +69,7 @@ def make_media_type(resource, lifecycle_change=None, organization=None, public=F
         # qualify the message with the kind of lifecycle change
         lifecycle_change.value,
         # specify the resource name
-        underscore(resource),
+        name_for(resource),
     )
 
 

--- a/microcosm_pubsub/tests/test_conventions.py
+++ b/microcosm_pubsub/tests/test_conventions.py
@@ -17,6 +17,10 @@ from microcosm_pubsub.conventions import created, make_media_type, URIMessageSch
 from microcosm_pubsub.decorators import handles
 
 
+class Foo(object):
+    pass
+
+
 @handles(created("foo"))
 def noop_handler(message):
     return True
@@ -117,7 +121,7 @@ def test_dispatch_by_convention():
     """
     graph = create_object_graph("example", testing=True)
 
-    media_type = created("Foo")
+    media_type = created(Foo)
 
     assert_that(
         graph.pubsub_message_schema_registry[media_type].schema,

--- a/microcosm_pubsub/tests/test_conventions.py
+++ b/microcosm_pubsub/tests/test_conventions.py
@@ -1,0 +1,130 @@
+"""
+Convention tests.
+
+"""
+from json import dumps, loads
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+    instance_of,
+    is_
+)
+from microcosm.api import create_object_graph
+
+from microcosm_pubsub.codecs import PubSubMessageCodec
+from microcosm_pubsub.conventions import created, make_media_type, URIMessageSchema
+from microcosm_pubsub.decorators import handles
+
+
+@handles(created("foo"))
+def noop_handler(message):
+    return True
+
+
+def test_make_media_type():
+    """
+    Media type construction should generate the correct type strings.
+
+    """
+    cases = [
+        (("foo",), dict(), "application/vnd.globality.pubsub._.created.foo"),
+        (("foo",), dict(public=True), "application/vnd.globality.pubsub.created.foo"),
+        (("foo",), dict(organization="example"), "application/vnd.example.pubsub._.created.foo"),
+        (("FooBar",), dict(), "application/vnd.globality.pubsub._.created.foo_bar"),
+        (("FooBar.ThisThat",), dict(), "application/vnd.globality.pubsub._.created.foo_bar.this_that"),
+    ]
+
+    def validate(args, kargs, expected):
+        assert_that(make_media_type(*args, **kwargs), is_(equal_to(expected)))
+
+    for args, kwargs, expected in cases:
+        yield validate, args, kwargs, expected
+
+
+def test_encode_uri_message_schema():
+    """
+    Message encoding should include the standard fields.
+
+    """
+    schema = URIMessageSchema(make_media_type("Foo"))
+    codec = PubSubMessageCodec(schema)
+    assert_that(
+        loads(codec.encode(
+            opaque_data=dict(foo="bar"),
+            uri="http://example.com",
+        )),
+        is_(equal_to({
+            "mediaType": "application/vnd.globality.pubsub._.created.foo",
+            "opaqueData": {
+                "foo": "bar",
+            },
+            "uri": "http://example.com",
+        })),
+    )
+
+
+def test_decode_uri_message_schema():
+    """
+    Message decoding should process standard fields.
+
+    """
+    schema = URIMessageSchema(make_media_type("Foo"))
+    codec = PubSubMessageCodec(schema)
+    message = dumps({
+        "mediaType": "application/vnd.globality.pubsub.foo",
+        "opaqueData": {
+            "foo": "bar",
+        },
+        "uri": "http://example.com",
+    })
+    assert_that(codec.decode(message), is_(equal_to({
+        "media_type": "application/vnd.globality.pubsub.foo",
+        "opaque_data": dict(foo="bar"),
+        "uri": "http://example.com",
+    })))
+
+
+def test_publish_by_convention():
+    """
+    Message publishing can use this convention.
+
+    """
+    def loader(metadata):
+        return dict(
+            sns_topic_arns=dict(
+                default="default",
+            )
+        )
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+
+    graph.sns_producer.produce(created("foo"), uri="http://example.com", opaque_data=dict())
+
+    assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))
+    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["TopicArn"], is_(equal_to("default")))
+    assert_that(loads(graph.sns_producer.sns_client.publish.call_args[1]["Message"]), is_(equal_to({
+        "mediaType": "application/vnd.globality.pubsub._.created.foo",
+        "uri": "http://example.com",
+        "opaqueData": {},
+    })))
+
+
+def test_dispatch_by_convention():
+    """
+    Message dispatch can use this convention.
+
+    """
+    graph = create_object_graph("example", testing=True)
+
+    media_type = created("Foo")
+
+    assert_that(
+        graph.pubsub_message_schema_registry[media_type].schema,
+        is_(instance_of(URIMessageSchema)),
+    )
+
+    assert_that(
+        graph.sqs_message_handler_registry[media_type],
+        is_(equal_to(noop_handler)),
+    )

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -74,7 +74,7 @@ def test_produce_default_topic():
     assert_that(loads(graph.sns_producer.sns_client.publish.call_args[1]["Message"]), is_(equal_to({
         "bar": "baz",
         "mediaType": "application/vnd.globality.pubsub.foo",
-        "opaque_data": {},
+        "opaqueData": {},
     })))
     assert_that(message_id, is_(equal_to(MESSAGE_ID)))
 
@@ -110,7 +110,7 @@ def test_produce_custom_topic():
     assert_that(loads(graph.sns_producer.sns_client.publish.call_args[1]["Message"]), is_(equal_to({
         "bar": "baz",
         "mediaType": "application/vnd.globality.pubsub.foo",
-        "opaque_data": {},
+        "opaqueData": {},
     })))
     assert_that(message_id, is_(equal_to(MESSAGE_ID)))
 


### PR DESCRIPTION
In a (immutable) event-driven system, pubsub messages are just reflections of state changes made
in some source of truth, typically a CRUD-oriented microservice. (See `microcosm-flask`).

These state changes can be represented very simply as a type and URI, plus some optional opaque
data for accounting/logging purposes. During a normal message handling flow, the consumer queries
back to the source of truth (by URI) and fetches further information. Only in unusual circumstances
do the messages need to convey further information, usually as an optimization to short circuit
extra queries.

This change set makes messages of this sort sort automatic. It:

 - Defines a convention for generating media types based on a resource and a lifecycle change
 - Defines a base `URIMessageSchema` that can be used (instead of defining custom schemas for every message)
 - Extends the schema registry to (optionally) be aware of these messages
 - Defines semantic sugar to easily construct such messages.

Example #1:

    # producing a message without defining a schema
    graph.sns_producer.produce(created(MyResource), uri="http://example.com", opaque_data=dict())

Example #2:

    # registering a message handler without defining a schema
    @handles(created(MyResource))
    def my_handler(message):
        pass

With these conventions, micro services (mostly) do not need to define message types for pubsub processing.