### PR TITLE
Release 0.14.0: Set type for values returned from config object

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.21.0
+current_version = 0.22.0
 commit = False
 tag = False
 

--- a/microcosm_pubsub/conventions.py
+++ b/microcosm_pubsub/conventions.py
@@ -23,6 +23,7 @@ class LifecycleChange(Enum):
     Changed = u"changed"
     Created = u"created"
     Deleted = u"deleted"
+    Stopped = u"stopped"
 
     def matches(self, media_type):
         return self.value in media_type.split(".")
@@ -116,3 +117,11 @@ def deleted(resource, **kwargs):
 
     """
     return make_media_type(resource, lifecycle_change=LifecycleChange.Deleted, **kwargs)
+
+
+def stopped(resource, **kwargs):
+    """
+    Fluent wrapper around message publishing for convention-driven schemas.
+
+    """
+    return make_media_type(resource, lifecycle_change=LifecycleChange.Stopped, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm_pubsub"
-version = "0.21.0"
+version = "0.22.0"
 
 setup(
     name=project,


### PR DESCRIPTION
We ran into issues related to DynamoDB storing everything as unicode. When
we pull the config from credstash we encountered type mismatches.

This should fix it for the SQS limits and timeouts.