### PR TITLE
Pinned marshmallow to latest known working version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.22.0
+current_version = 0.22.1
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm_pubsub"
-version = "0.22.0"
+version = "0.22.1"
 
 setup(
     name=project,
@@ -16,7 +16,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "boto3>=1.3.0",
-        "marshmallow>=2.6.1",
+        "marshmallow==2.11.1",
         "microcosm>=0.13.0",
         "microcosm-daemon>=0.8.0",
         "microcosm-logging>=0.12.0",


### PR DESCRIPTION
https://github.com/marshmallow-code/marshmallow/pull/572#issuecomment-274433782
caused builds to break. Until
https://github.com/marshmallow-code/marshmallow/pull/575 is figured out,
we will pin to `2.11.1` which is known to work.