### PR TITLE
Use handler logger where possible.

### DIFF
--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -89,7 +89,7 @@ class SQSMessageDispatcher(object):
                         extra=self.sqs_message_context(message)
                     )
                 else:
-                    logger.info(
+                    logger.error(
                         "Error handling SQS message: {}".format(
                             media_type,
                          ),

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -77,8 +77,9 @@ class SQSMessageDispatcher(object):
             except Exception as error:
                 # NB if possible, log with the handler's logger to make it easier
                 # to tell which handler failed in the logs.
-                logger = getattr(sqs_message_handler, "logger", None)
-                if logger is None:
+                try:
+                    logger = sqs_message_handler.logger
+                except AttributeError:
                     logger = self.logger
 
                 if isinstance(error, Nack):
@@ -89,7 +90,7 @@ class SQSMessageDispatcher(object):
                         extra=self.sqs_message_context(message)
                     )
                 else:
-                    logger.error(
+                    logger.warning(
                         "Error handling SQS message: {}".format(
                             media_type,
                          ),

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -45,22 +45,7 @@ class SQSMessageDispatcher(object):
                 with message:
                     if not self.handle_message(message.media_type, message.content):
                         ignore_count += 1
-            except Exception as error:
-                if isinstance(error, Nack):
-                    self.logger.info(
-                        "Nacking SQS message: {}".format(
-                            message.media_type,
-                        ),
-                        extra=self.sqs_message_context(message.content)
-                    )
-                else:
-                    self.logger.info(
-                        "Error handling SQS message: {}".format(
-                            message.media_type,
-                        ),
-                        exc_info=True,
-                        extra=self.sqs_message_context(message.content)
-                    )
+            except Exception:
                 error_count += 1
 
         return DispatchResult(message_count, error_count, ignore_count)
@@ -81,13 +66,37 @@ class SQSMessageDispatcher(object):
                 # no handlers
                 self.logger.debug("Skipping message with no registered handler: {}".format(media_type))
                 return False
-            else:
+
+            try:
                 handler_with_context = context_logger(
                     self.sqs_message_context,
                     sqs_message_handler,
                     parent=sqs_message_handler,
                 )
                 return handler_with_context(message)
+            except Exception as error:
+                # NB if possible, log with the handler's logger to make it easier
+                # to tell which handler failed in the logs.
+                logger = getattr(sqs_message_handler, "logger", None)
+                if logger is None:
+                    logger = self.logger
+
+                if isinstance(error, Nack):
+                    logger.info(
+                        "Nacking SQS message: {}".format(
+                            media_type,
+                        ),
+                        extra=self.sqs_message_context(message)
+                    )
+                else:
+                    logger.info(
+                        "Error handling SQS message: {}".format(
+                            media_type,
+                         ),
+                        exc_info=True,
+                        extra=self.sqs_message_context(message)
+                     )
+                raise error
 
 
 def configure(graph):


### PR DESCRIPTION
On error, log with the handler's logger to make it clearer in
logging which handler failed.

Today we log things like:
```
  1 2017-02-02 09:24:50,849 - SQSMessageDispatcher - [INFO] - Error handling SQS message: application/vnd.globality.pubsub._.created.service_project
  2 Traceback (most recent call last):
  3   File "/Users/dino/.virtualenvs/blanca/lib/python2.7/site-packages/microcosm_pubsub/dispatcher.py", line 46, in handle_batch
  4     if not self.handle_message(message.media_type, message.content):
  5   File "/Users/dino/.virtualenvs/blanca/lib/python2.7/site-packages/microcosm_pubsub/dispatcher.py", line 90, in handle_message
  6     return handler_with_context(message)
  7   File "/Users/dino/globality/microcosm-logging/microcosm_logging/decorators.py", line 57, in wrapped
  8     result = func(*args, **kwargs)
  9   File "/Users/dino/.virtualenvs/blanca/lib/python2.7/site-packages/microcosm_pubsub/handlers.py", line 58, in __call__
 10     if self.handle(message, uri, resource):
 11   File "/Users/dino/globality/blanca/blanca/daemon/handlers/platform_event_handlers.py", line 101, in handle
 12     raise Exception("poopie")
 13 Exception: poopie
```

This will give us logs like:

```
 15 2017-02-02 09:58:31,605 - NewPermissionEventHandler - [INFO] - Error handling SQS message: application/vnd.globality.pubsub._.created.permission_event
 16 Traceback (most recent call last):
 17   File "/Users/dino/globality/microcosm-pubsub/microcosm_pubsub/dispatcher.py", line 77, in handle_message
 18     return handler_with_context(message)
 19   File "/Users/dino/globality/microcosm-logging/microcosm_logging/decorators.py", line 57, in wrapped
 20     result = func(*args, **kwargs)
 21   File "/Users/dino/globality/microcosm-pubsub/microcosm_pubsub/handlers.py", line 58, in __call__
 22     if self.handle(message, uri, resource):
 23   File "/Users/dino/globality/blanca/blanca/daemon/handlers/new_permission_event_handler.py", line 61, in handle
 24     raise Exception("poopie")
```

Making it much easier to search for errors by handler.
