### PR TITLE
Simplify and clarify pubsub registry interactions

### DIFF
--- a/microcosm_pubsub/conventions.py
+++ b/microcosm_pubsub/conventions.py
@@ -25,8 +25,12 @@ class LifecycleChange(Enum):
     Deleted = u"deleted"
     Stopped = u"stopped"
 
-    def matches(self, media_type):
-        return self.value in media_type.split(".")
+    @classmethod
+    def matches(cls, media_type):
+        return any(
+            item.value in media_type.split(".")
+            for item in cls
+        )
 
 
 def name_for(obj):

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -25,8 +25,6 @@ class ConsumerDaemon(Daemon):
         )
 
     def run_state_machine(self):
-        self.compute_bound_handlers()
-
         for media_type, handler in self.bound_handlers.items():
             self.graph.logger.info("Handling: {} with handler: {}".format(
                 media_type,

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -2,6 +2,7 @@
 Registry of SQS message handlers.
 
 """
+from collections import defaultdict
 from inspect import isclass
 from six import string_types
 
@@ -10,6 +11,14 @@ from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.codecs import PubSubMessageCodec
 from microcosm_pubsub.conventions import LifecycleChange, URIMessageSchema
+
+
+def hashable(value):
+    try:
+        hash(value)
+    except TypeError:
+        return False
+    return True
 
 
 class AlreadyRegisteredError(Exception):
@@ -23,6 +32,7 @@ class PubSubMessageSchemaRegistry(object):
 
     """
     def __init__(self, graph):
+        self._media_types = set()
         self._mappings = dict()
         self.graph = graph
         self.auto_register = graph.config.pubsub_message_schema_registry.auto_register
@@ -35,12 +45,17 @@ class PubSubMessageSchemaRegistry(object):
         It is an error to register more than one value for the same media type.
 
         """
+        self._media_types.add(media_type)
+
+        if isinstance(value, string_types):
+            # When using the @handles convention, there may not be a concrete schema class declared.
+            # In this case, the media type itself is passed as the value.
+            # thereby allowing handlers to be declared using convention-driven
+            return
+
         existing_value = self._mappings.get(media_type)
         if existing_value:
             if value == existing_value:
-                return
-            # NB: Caching scopes and graph hooks are not cooperating currently
-            if self.graph.metadata.testing:
                 return
             raise AlreadyRegisteredError("A schema already exists for media type: {}".format(
                 media_type,
@@ -52,28 +67,22 @@ class PubSubMessageSchemaRegistry(object):
         Create a codec or raise KeyError.
 
         """
-        try:
-            schema_cls = self._mappings[media_type]
-            if isinstance(schema_cls, string_types):
-                media_type = schema_cls
-                schema = URIMessageSchema(media_type)
+        if media_type not in self._media_types:
+            if self.auto_register and LifecycleChange.matches(media_type):
+                # When using convention-based media types, we may need to auto-register
+                self._media_types.add(media_type)
             else:
-                schema = schema_cls(strict=self.strict)
-        except KeyError:
-            if not self.auto_register:
-                raise
+                raise KeyError("Unregistered media type: {}".format(media_type))
 
-            for lifecycle_change in LifecycleChange:
-                if lifecycle_change.matches(media_type):
-                    schema = URIMessageSchema(media_type)
-                    break
-            else:
-                raise
+        try:
+            # use a concrete schema class if any
+            schema_cls = self._mappings[media_type]
+            schema = schema_cls(strict=self.strict)
+        except KeyError:
+            # use convention otherwise
+            schema = URIMessageSchema(media_type)
 
         return PubSubMessageCodec(schema)
-
-    def keys(self):
-        return self._mappings.keys()
 
 
 @logger
@@ -83,29 +92,42 @@ class SQSMessageHandlerRegistry(object):
 
     """
     def __init__(self, graph):
-        self._mappings = dict()
+        self._mappings = defaultdict(set)
         self.graph = graph
 
     def register(self, media_type, handler):
-        existing_value = self._mappings.get(media_type)
-        if existing_value:
-            if handler == existing_value:
-                return
-            # NB: Caching scopes and graph hooks are not cooperating currently
-            if self.graph.metadata.testing:
-                return
-            raise AlreadyRegisteredError("A handler already exists for media type: {}".format(
-                media_type,
-            ))
-        self._mappings[media_type] = handler
+        self._mappings[media_type].add(handler)
 
-    def find(self, media_type):
-        handler = self._mappings[media_type]
+    def compute_bound_handlers(self, bindings):
+        """
+        Compute which handlers are bound to the graph.
+
+        In cases where multiple daemons exist in the same code base, it's possible that
+        the registry will include handlers that aren't currently bound.
+
+        """
+        bound_components = [
+            getattr(self.graph, binding)
+            for binding in bindings
+        ]
+        return {
+            media_type: handler
+            for media_type, handler in self.iter_handlers()
+            if handler in bound_components
+        }
+
+    def find(self, media_type, bound_handlers):
+        handler = bound_handlers[media_type]
 
         if isclass(handler):
             return handler(self.graph)
         else:
             return handler
+
+    def iter_handlers(self):
+        for media_type, handlers in self._mappings.items():
+            for handler in handlers:
+                yield media_type, handler
 
     def keys(self):
         return self._mappings.keys()

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -13,14 +13,6 @@ from microcosm_pubsub.codecs import PubSubMessageCodec
 from microcosm_pubsub.conventions import LifecycleChange, URIMessageSchema
 
 
-def hashable(value):
-    try:
-        hash(value)
-    except TypeError:
-        return False
-    return True
-
-
 class AlreadyRegisteredError(Exception):
     pass
 

--- a/microcosm_pubsub/tests/test_codecs.py
+++ b/microcosm_pubsub/tests/test_codecs.py
@@ -1,5 +1,5 @@
 """
-Codec tests.
+Message encoding tests.
 
 """
 from json import dumps, loads
@@ -15,7 +15,7 @@ from hamcrest import (
 from marshmallow import ValidationError
 from microcosm.api import create_object_graph
 
-from microcosm_pubsub.tests.fixtures import FooSchema
+from microcosm_pubsub.tests.fixtures import DerivedSchema
 
 
 def test_no_default_schema():
@@ -25,7 +25,7 @@ def test_no_default_schema():
     """
     graph = create_object_graph("example", testing=True)
     assert_that(
-        calling(graph.pubsub_message_schema_registry.find).with_args("bar"),
+        calling(graph.pubsub_message_schema_registry.find).with_args("unknown"),
         raises(KeyError),
     )
 
@@ -36,8 +36,8 @@ def test_custom_schema():
 
     """
     graph = create_object_graph("example", testing=True)
-    codec = graph.pubsub_message_schema_registry.find(FooSchema.MEDIA_TYPE)
-    assert_that(codec.schema, is_(instance_of(FooSchema)))
+    codec = graph.pubsub_message_schema_registry.find(DerivedSchema.MEDIA_TYPE)
+    assert_that(codec.schema, is_(instance_of(DerivedSchema)))
 
 
 def test_encode():
@@ -46,10 +46,10 @@ def test_encode():
 
     """
     graph = create_object_graph("example", testing=True)
-    codec = graph.pubsub_message_schema_registry.find(FooSchema.MEDIA_TYPE)
-    assert_that(loads(codec.encode(bar="baz")), is_(equal_to({
-        "bar": "baz",
-        "mediaType": "application/vnd.globality.pubsub.foo",
+    codec = graph.pubsub_message_schema_registry.find(DerivedSchema.MEDIA_TYPE)
+    assert_that(loads(codec.encode(data="data")), is_(equal_to({
+        "data": "data",
+        "mediaType": DerivedSchema.MEDIA_TYPE,
     })))
 
 
@@ -59,8 +59,8 @@ def test_encode_missing_field():
 
     """
     graph = create_object_graph("example", testing=True)
-    codec = graph.pubsub_message_schema_registry.find(FooSchema.MEDIA_TYPE)
-    assert_that(calling(codec.encode).with_args(baz="bar"), raises(ValidationError))
+    codec = graph.pubsub_message_schema_registry.find(DerivedSchema.MEDIA_TYPE)
+    assert_that(calling(codec.encode), raises(ValidationError))
 
 
 def test_decode():
@@ -69,14 +69,14 @@ def test_decode():
 
     """
     graph = create_object_graph("example", testing=True)
-    codec = graph.pubsub_message_schema_registry.find(FooSchema.MEDIA_TYPE)
+    codec = graph.pubsub_message_schema_registry.find(DerivedSchema.MEDIA_TYPE)
     message = dumps({
-        "bar": "baz",
-        "mediaType": "application/vnd.globality.pubsub.foo",
+        "data": "data",
+        "mediaType": DerivedSchema.MEDIA_TYPE,
     })
     assert_that(codec.decode(message), is_(equal_to({
-        "bar": "baz",
-        "media_type": "application/vnd.globality.pubsub.foo",
+        "data": "data",
+        "media_type": DerivedSchema.MEDIA_TYPE,
     })))
 
 
@@ -86,7 +86,7 @@ def test_decode_missing_media_type():
 
     """
     graph = create_object_graph("example", testing=True)
-    codec = graph.pubsub_message_schema_registry.find(FooSchema.MEDIA_TYPE)
+    codec = graph.pubsub_message_schema_registry.find(DerivedSchema.MEDIA_TYPE)
     message = dumps({
         "bar": "baz",
     })
@@ -99,8 +99,8 @@ def test_decode_missing_field():
 
     """
     graph = create_object_graph("example", testing=True)
-    codec = graph.pubsub_message_schema_registry.find(FooSchema.MEDIA_TYPE)
+    codec = graph.pubsub_message_schema_registry.find(DerivedSchema.MEDIA_TYPE)
     message = dumps({
-        "mediaType": "application/vnd.globality.pubsub.foo",
+        "mediaType": DerivedSchema.MEDIA_TYPE,
     })
     assert_that(calling(codec.decode).with_args(message), raises(ValidationError))

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -14,13 +14,11 @@ from mock import patch
 
 from microcosm_pubsub.errors import Nack
 from microcosm_pubsub.message import SQSMessage
-from microcosm_pubsub.tests.fixtures import (
-    ExampleDaemon,
-    FOO_MEDIA_TYPE,
-    FooSchema,
-    MESSAGE_ID,
-    RECEIPT_HANDLE,
-)
+from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon
+
+
+MESSAGE_ID = "message-id"
+RECEIPT_HANDLE = "receipt-handle"
 
 
 def test_consume():
@@ -36,8 +34,8 @@ def test_consume():
         MD5OfBody="7efaa8404863d47c51ed0e20b9014aec",
         Body=dumps(dict(
             Message=dumps(dict(
-                bar="baz",
-                mediaType=FOO_MEDIA_TYPE,
+                data="data",
+                mediaType=DerivedSchema.MEDIA_TYPE,
             )),
         ))),
     ])
@@ -57,8 +55,8 @@ def test_consume():
     assert_that(messages[0].message_id, is_(equal_to(MESSAGE_ID)))
     assert_that(messages[0].receipt_handle, is_(equal_to(RECEIPT_HANDLE)))
     assert_that(messages[0].content, is_(equal_to(dict(
-        bar="baz",
-        media_type=FOO_MEDIA_TYPE,
+        data="data",
+        media_type=DerivedSchema.MEDIA_TYPE,
     ))))
 
 
@@ -71,7 +69,7 @@ def test_nack_without_visibility_timeout():
     message = SQSMessage(
         consumer=graph.sqs_consumer,
         content=None,
-        media_type=FooSchema.MEDIA_TYPE,
+        media_type=DerivedSchema.MEDIA_TYPE,
         message_id=MESSAGE_ID,
         receipt_handle=RECEIPT_HANDLE,
     )
@@ -89,7 +87,7 @@ def test_nack_with_visibility_timeout():
     message = SQSMessage(
         consumer=graph.sqs_consumer,
         content=None,
-        media_type=FooSchema.MEDIA_TYPE,
+        media_type=DerivedSchema.MEDIA_TYPE,
         message_id=MESSAGE_ID,
         receipt_handle=RECEIPT_HANDLE,
     )
@@ -112,7 +110,7 @@ def test_nack_with_visibility_timeout_via_exception():
     message = SQSMessage(
         consumer=graph.sqs_consumer,
         content=None,
-        media_type=FooSchema.MEDIA_TYPE,
+        media_type=DerivedSchema.MEDIA_TYPE,
         message_id=MESSAGE_ID,
         receipt_handle=RECEIPT_HANDLE,
     )
@@ -139,7 +137,7 @@ def test_ack():
     message = SQSMessage(
         consumer=graph.sqs_consumer,
         content=None,
-        media_type=FooSchema.MEDIA_TYPE,
+        media_type=DerivedSchema.MEDIA_TYPE,
         message_id=MESSAGE_ID,
         receipt_handle=RECEIPT_HANDLE,
     )

--- a/microcosm_pubsub/tests/test_decorators.py
+++ b/microcosm_pubsub/tests/test_decorators.py
@@ -8,28 +8,31 @@ from hamcrest import (
     instance_of,
     is_,
 )
-from microcosm.api import create_object_graph
 
-from microcosm_pubsub.tests.fixtures import noop_handler, TestSchema
+from microcosm_pubsub.tests.fixtures import (
+    DuckTypeSchema,
+    ExampleDaemon,
+    noop_handler,
+)
 
 
 class TestDecorators(object):
 
     def setup(self):
-        self.graph = create_object_graph("test", testing=True)
-        self.graph.use(
-            "pubsub_message_schema_registry",
-            "sqs_message_handler_registry",
-        )
+        self.daemon = ExampleDaemon.create_for_testing()
+        self.graph = self.daemon.graph
 
     def test_schema_decorators(self):
         assert_that(
-            self.graph.pubsub_message_schema_registry.find(TestSchema.MEDIA_TYPE).schema,
-            is_(instance_of(TestSchema)),
+            self.graph.pubsub_message_schema_registry.find(DuckTypeSchema.MEDIA_TYPE).schema,
+            is_(instance_of(DuckTypeSchema)),
         )
 
     def test_handles_decorators(self):
         assert_that(
-            self.graph.sqs_message_handler_registry.find(TestSchema.MEDIA_TYPE),
+            self.graph.sqs_message_handler_registry.find(
+                DuckTypeSchema.MEDIA_TYPE,
+                self.daemon.bound_handlers,
+            ),
             is_(equal_to(noop_handler)),
         )

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -12,7 +12,7 @@ from mock import Mock
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.tests.fixtures import (
     ExampleDaemon,
-    FooSchema,
+    DerivedSchema,
 )
 
 
@@ -21,11 +21,17 @@ def test_handle():
     Test that the dispatcher handles a message and assigns context.
 
     """
-    graph = ExampleDaemon.create_for_testing().graph
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+
     message = dict(bar="baz")
     sqs_message_context = Mock(return_value=dict())
     with graph.opaque.initialize(sqs_message_context, message):
-        result = graph.sqs_message_dispatcher.handle_message(FooSchema.MEDIA_TYPE, message)
+        result = graph.sqs_message_dispatcher.handle_message(
+            DerivedSchema.MEDIA_TYPE,
+            message,
+            daemon.bound_handlers,
+        )
 
     assert_that(result, is_(equal_to(True)))
     sqs_message_context.assert_called_once_with(message)
@@ -36,14 +42,19 @@ def test_handle_with_no_context():
     Test that when no context is added the dispatcher behaves sanely.
 
     """
-    graph = ExampleDaemon.create_for_testing().graph
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
 
     # remove the sqs_message_context from the graph so we can test the dispatcher
     # defaulting logic
-    graph._registry.entry_points.pop('sqs_message_context')
+    graph._registry.entry_points.pop("sqs_message_context")
 
     message = dict(bar="baz")
-    result = graph.sqs_message_dispatcher.handle_message(FooSchema.MEDIA_TYPE, message)
+    result = graph.sqs_message_dispatcher.handle_message(
+        DerivedSchema.MEDIA_TYPE,
+        message,
+        daemon.bound_handlers,
+    )
 
     assert_that(result, is_(equal_to(True)))
     assert_that(graph.sqs_message_dispatcher.sqs_message_context(message), is_(equal_to(dict())))
@@ -54,7 +65,13 @@ def test_handle_with_skipping():
     Test that skipping works
 
     """
-    graph = ExampleDaemon.create_for_testing().graph
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+
     message = dict(bar="baz")
-    result = graph.sqs_message_dispatcher.handle_message(created("bar"), message)
+    result = graph.sqs_message_dispatcher.handle_message(
+        created("bar"),
+        message,
+        daemon.bound_handlers,
+    )
     assert_that(result, is_(equal_to(False)))

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -20,11 +20,10 @@ import microcosm.opaque  # noqa
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.errors import TopicNotDefinedError
 from microcosm_pubsub.producer import DeferredProducer, iter_topic_mappings
-from microcosm_pubsub.tests.fixtures import (
-    FOO_TOPIC,
-    FOO_MEDIA_TYPE,
-    MESSAGE_ID,
-)
+from microcosm_pubsub.tests.fixtures import DerivedSchema
+
+
+MESSAGE_ID = "message-id"
 
 
 def test_produce_no_topic_arn():
@@ -40,7 +39,7 @@ def test_produce_no_topic_arn():
 
     graph = create_object_graph("example", testing=True, loader=loader)
     assert_that(
-        calling(graph.sns_producer.produce).with_args(FOO_MEDIA_TYPE, bar="baz"),
+        calling(graph.sns_producer.produce).with_args(DerivedSchema.MEDIA_TYPE, data="data"),
         raises(TopicNotDefinedError),
     )
 
@@ -53,7 +52,7 @@ def test_produce_default_topic():
     def loader(metadata):
         return dict(
             sns_topic_arns=dict(
-                default=FOO_TOPIC,
+                default="topic",
             )
         )
 
@@ -62,13 +61,13 @@ def test_produce_default_topic():
     # set up response
     graph.sns_producer.sns_client.publish.return_value = dict(MessageId=MESSAGE_ID)
 
-    message_id = graph.sns_producer.produce(FOO_MEDIA_TYPE, bar="baz")
+    message_id = graph.sns_producer.produce(DerivedSchema.MEDIA_TYPE, data="data")
 
     assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))
-    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["TopicArn"], is_(equal_to(FOO_TOPIC)))
+    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["TopicArn"], is_(equal_to("topic")))
     assert_that(loads(graph.sns_producer.sns_client.publish.call_args[1]["Message"]), is_(equal_to({
-        "bar": "baz",
-        "mediaType": "application/vnd.globality.pubsub.foo",
+        "data": "data",
+        "mediaType": DerivedSchema.MEDIA_TYPE,
         "opaqueData": {},
     })))
     assert_that(message_id, is_(equal_to(MESSAGE_ID)))
@@ -84,7 +83,7 @@ def test_produce_custom_topic():
             sns_topic_arns=dict(
                 default=None,
                 mappings={
-                    FOO_MEDIA_TYPE: FOO_TOPIC,
+                    DerivedSchema.MEDIA_TYPE: "special-topic",
                 },
             )
         )
@@ -95,13 +94,13 @@ def test_produce_custom_topic():
     # set up response
     graph.sns_producer.sns_client.publish.return_value = dict(MessageId=MESSAGE_ID)
 
-    message_id = graph.sns_producer.produce(FOO_MEDIA_TYPE, bar="baz")
+    message_id = graph.sns_producer.produce(DerivedSchema.MEDIA_TYPE, data="data")
 
     assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))
-    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["TopicArn"], is_(equal_to(FOO_TOPIC)))
+    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["TopicArn"], is_(equal_to("special-topic")))
     assert_that(loads(graph.sns_producer.sns_client.publish.call_args[1]["Message"]), is_(equal_to({
-        "bar": "baz",
-        "mediaType": "application/vnd.globality.pubsub.foo",
+        "data": "data",
+        "mediaType": DerivedSchema.MEDIA_TYPE,
         "opaqueData": {},
     })))
     assert_that(message_id, is_(equal_to(MESSAGE_ID)))
@@ -136,11 +135,11 @@ def test_produce_custom_topic_environ():
 
     """
     key = "EXAMPLE__SNS_TOPIC_ARNS__CREATED__FOO__BAR_BAZ"
-    environ[key] = "foo-topic"
+    environ[key] = "topic"
     graph = create_object_graph("example", testing=True, loader=load_from_environ)
     graph.sns_producer.produce(created("foo.bar_baz"), bar="baz")
     assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))
-    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["TopicArn"], is_(equal_to(FOO_TOPIC)))
+    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["TopicArn"], is_(equal_to("topic")))
 
 
 def test_deferred_production():
@@ -151,7 +150,7 @@ def test_deferred_production():
     def loader(metadata):
         return dict(
             sns_topic_arns=dict(
-                default=FOO_TOPIC,
+                default="topic",
             )
         )
 
@@ -162,8 +161,7 @@ def test_deferred_production():
     graph.sns_producer.sns_client.publish.return_value = dict(MessageId=MESSAGE_ID)
 
     with DeferredProducer(graph.sns_producer) as producer:
-        assert_that(producer.produce(FOO_MEDIA_TYPE, bar="baz"), is_(none()))
-
+        assert_that(producer.produce(DerivedSchema.MEDIA_TYPE, data="data"), is_(none()))
         assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(0)))
 
     assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))

--- a/microcosm_pubsub/tests/test_registry.py
+++ b/microcosm_pubsub/tests/test_registry.py
@@ -14,7 +14,7 @@ from microcosm.api import create_object_graph
 
 from microcosm_pubsub.codecs import DEFAULT_MEDIA_TYPE, PubSubMessageSchema
 import microcosm_pubsub.registry  # noqa: F401
-from microcosm_pubsub.tests.fixtures import foo_handler, FooSchema
+from microcosm_pubsub.tests.fixtures import DerivedSchema, noop_handler
 
 
 def another_handler(message):
@@ -22,10 +22,10 @@ def another_handler(message):
 
 
 class AnotherSchema(PubSubMessageSchema):
-    MEDIA_TYPE = "application/vnd.globality.pubsub.test"
+    MEDIA_TYPE = "application/vnd.microcosm.another"
 
 
-class FooPubSubMessageCodecRegistry(object):
+class DerivedPubSubMessageCodecRegistry(object):
 
     def setup(self):
         self.graph = create_object_graph("test")
@@ -36,23 +36,23 @@ class FooPubSubMessageCodecRegistry(object):
         assert_that(schemas, is_(empty()))
 
     def test_iterate_found(self):
-        schemas = list(self.registry.iterate(FooSchema.MEDIA_TYPE))
+        schemas = list(self.registry.iterate(DerivedSchema.MEDIA_TYPE))
         assert_that(schemas, has_length(1))
 
     def test_iterate_multiple_not_allowed(self):
         assert_that(
-            calling(self.registry.register).with_args(FooSchema.MEDIA_TYPE, AnotherSchema),
+            calling(self.registry.register).with_args(DerivedSchema.MEDIA_TYPE, AnotherSchema),
             raises(Exception),
         )
 
     def test_iterate_duplicate(self):
         assert_that(
-            calling(self.registry.register).with_args(FooSchema.MEDIA_TYPE, FooSchema),
+            calling(self.registry.register).with_args(DerivedSchema.MEDIA_TYPE, DerivedSchema),
             raises(Exception),
         )
 
 
-class FooSQSMessageHandlerRegistry(object):
+class DerivedSQSMessageHandlerRegistry(object):
 
     def setup(self):
         self.graph = create_object_graph("test")
@@ -63,16 +63,16 @@ class FooSQSMessageHandlerRegistry(object):
         assert_that(handlers, is_(empty()))
 
     def test_iterate_found(self):
-        handlers = list(self.registry.iterate(FooSchema.MEDIA_TYPE))
+        handlers = list(self.registry.iterate(DerivedSchema.MEDIA_TYPE))
         assert_that(handlers, has_length(1))
 
     def test_iterate_multiple(self):
-        self.registry.register(FooSchema.MEDIA_TYPE, another_handler)
-        handlers = list(self.registry.iterate(FooSchema.MEDIA_TYPE))
+        self.registry.register(DerivedSchema.MEDIA_TYPE, another_handler)
+        handlers = list(self.registry.iterate(DerivedSchema.MEDIA_TYPE))
         assert_that(handlers, has_length(2))
 
     def test_iterate_duplicate(self):
         assert_that(
-            calling(self.registry.register).with_args(FooSchema.MEDIA_TYPE, foo_handler),
+            calling(self.registry.register).with_args(DerivedSchema.MEDIA_TYPE, noop_handler),
             raises(Exception),
         )


### PR DESCRIPTION
Main changes:
 -  Clearly differentiate convention-driven and class-driven schema registration
 -  Handle cases with multiple daemons registering different handlers for the same media type
 -  Make fixtures more obvious