### PR TITLE
Simplify testing real daemons with fake queues

### DIFF
--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -95,6 +95,9 @@ def configure_sqs_consumer(graph):
     if graph.metadata.testing:
         from mock import MagicMock
         sqs_client = MagicMock()
+    elif sqs_queue_url == "test":
+        from mock import MagicMock
+        sqs_client = MagicMock()
     else:
         sqs_client = client("sqs")
 


### PR DESCRIPTION
This allows us to run:

    some-consume-daemon --sqs-queue-url test

And exercise behavior not tied to SQS consumption.