### PR TITLE
Use identity-based convention for deleted lifecycle changes

### DIFF
--- a/microcosm_pubsub/conventions.py
+++ b/microcosm_pubsub/conventions.py
@@ -99,6 +99,24 @@ class URIMessageSchema(PubSubMessageSchema):
         return self.MEDIA_TYPE
 
 
+class IdentityMessageSchema(PubSubMessageSchema):
+    """
+    Define a baseline message schema that points to (the identity of) a resource that experienced a lifecycle change.
+
+    In general, these conventions prefer URI-based messages, but for some lifecycle changes (e.g. deletion),
+    a URI may not be available.
+
+    """
+    def __init__(self, media_type, **kwargs):
+        super(PubSubMessageSchema, self).__init__(**kwargs)
+        self.MEDIA_TYPE = media_type
+
+    id = fields.String(required=True)
+
+    def deserialize_media_type(self, obj):
+        return self.MEDIA_TYPE
+
+
 def changed(resource, **kwargs):
     """
     Fluent wrapper around message publishing for convention-driven schemas.

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -10,7 +10,7 @@ from microcosm.api import defaults
 from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.codecs import PubSubMessageCodec
-from microcosm_pubsub.conventions import LifecycleChange, URIMessageSchema
+from microcosm_pubsub.conventions import LifecycleChange, IdentityMessageSchema, URIMessageSchema
 
 
 class AlreadyRegisteredError(Exception):
@@ -72,7 +72,10 @@ class PubSubMessageSchemaRegistry(object):
             schema = schema_cls(strict=self.strict)
         except KeyError:
             # use convention otherwise
-            schema = URIMessageSchema(media_type)
+            if LifecycleChange.Deleted.value in media_type.split("."):
+                schema = IdentityMessageSchema(media_type)
+            else:
+                schema = URIMessageSchema(media_type)
 
         return PubSubMessageCodec(schema)
 

--- a/microcosm_pubsub/tests/fixtures.py
+++ b/microcosm_pubsub/tests/fixtures.py
@@ -6,7 +6,7 @@ from marshmallow import fields, Schema
 
 from microcosm.api import binding
 from microcosm_pubsub.codecs import PubSubMessageSchema
-from microcosm_pubsub.conventions import created
+from microcosm_pubsub.conventions import created, deleted
 from microcosm_pubsub.daemon import ConsumerDaemon
 from microcosm_pubsub.decorators import handles, schema
 from microcosm_pubsub.errors import SkipMessage
@@ -39,6 +39,7 @@ class DuckTypeSchema(Schema):
 
 @handles(DuckTypeSchema)
 @handles(created("foo"))
+@handles(deleted("foo"))
 @handles(DerivedSchema.MEDIA_TYPE)
 def noop_handler(message):
     return True

--- a/microcosm_pubsub/tests/test_conventions.py
+++ b/microcosm_pubsub/tests/test_conventions.py
@@ -15,6 +15,8 @@ from microcosm.api import create_object_graph
 from microcosm_pubsub.codecs import PubSubMessageCodec
 from microcosm_pubsub.conventions import (
     created,
+    deleted,
+    IdentityMessageSchema,
     LifecycleChange,
     make_media_type,
     URIMessageSchema,
@@ -71,6 +73,28 @@ def test_encode_uri_message_schema():
     )
 
 
+def test_encode_identity_message_schema():
+    """
+    Message encoding should include the standard fields.
+
+    """
+    schema = IdentityMessageSchema(make_media_type("Foo", lifecycle_change=LifecycleChange.Deleted))
+    codec = PubSubMessageCodec(schema)
+    assert_that(
+        loads(codec.encode(
+            opaque_data=dict(foo="bar"),
+            id="1",
+        )),
+        is_(equal_to({
+            "mediaType": "application/vnd.globality.pubsub._.deleted.foo",
+            "opaqueData": {
+                "foo": "bar",
+            },
+            "id": "1",
+        })),
+    )
+
+
 def test_decode_uri_message_schema():
     """
     Message decoding should process standard fields.
@@ -92,7 +116,28 @@ def test_decode_uri_message_schema():
     })))
 
 
-def test_publish_by_convention():
+def test_decode_identity_message_schema():
+    """
+    Message decoding should process standard fields.
+
+    """
+    schema = IdentityMessageSchema(make_media_type("Foo"))
+    codec = PubSubMessageCodec(schema)
+    message = dumps({
+        "mediaType": "application/vnd.globality.pubsub.foo",
+        "opaqueData": {
+            "foo": "bar",
+        },
+        "id": "1",
+    })
+    assert_that(codec.decode(message), is_(equal_to({
+        "media_type": "application/vnd.globality.pubsub.foo",
+        "opaque_data": dict(foo="bar"),
+        "id": "1",
+    })))
+
+
+def test_publish_by_uri_convention():
     """
     Message publishing can use this convention.
 
@@ -117,7 +162,32 @@ def test_publish_by_convention():
     })))
 
 
-def test_dispatch_by_convention():
+def test_publish_by_identity_convention():
+    """
+    Message publishing can use this convention.
+
+    """
+    def loader(metadata):
+        return dict(
+            sns_topic_arns=dict(
+                default="default",
+            )
+        )
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+
+    graph.sns_producer.produce(deleted("foo"), id="1", opaque_data=dict())
+
+    assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))
+    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["TopicArn"], is_(equal_to("default")))
+    assert_that(loads(graph.sns_producer.sns_client.publish.call_args[1]["Message"]), is_(equal_to({
+        "mediaType": "application/vnd.globality.pubsub._.deleted.foo",
+        "id": "1",
+        "opaqueData": {},
+    })))
+
+
+def test_dispatch_by_uri_convention():
     """
     Message dispatch can use this convention.
 
@@ -130,6 +200,27 @@ def test_dispatch_by_convention():
     assert_that(
         graph.pubsub_message_schema_registry.find(media_type).schema,
         is_(instance_of(URIMessageSchema)),
+    )
+
+    assert_that(
+        graph.sqs_message_handler_registry.find(media_type, daemon.bound_handlers),
+        is_(equal_to(noop_handler)),
+    )
+
+
+def test_dispatch_by_identity_convention():
+    """
+    Message dispatch can use this convention.
+
+    """
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+
+    media_type = deleted(Foo)
+
+    assert_that(
+        graph.pubsub_message_schema_registry.find(media_type).schema,
+        is_(instance_of(IdentityMessageSchema)),
     )
 
     assert_that(


### PR DESCRIPTION
When a resource is deleted, it doesn't make sense to depend on a URI-based
message since the underlying object will usually not be accessible at its
URI any more. Use an identity-based schema instead.