### PR TITLE
Create decorator to allow for automatic message deferment

### DIFF
--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -187,6 +187,7 @@ def test_deferred_production_decorator():
         def bar(self):
             assert isinstance(self.sns_producer, DeferredProducer)
             self.sns_producer.produce(DerivedSchema.MEDIA_TYPE, data="data")
+            assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(0)))
 
     graph = create_object_graph("example", testing=True, loader=loader)
     foo = Foo(graph)


### PR DESCRIPTION
This decorator is intended to be used at the controller configuration
level, with the idea being that any messages produced within the context of a
controller function will be produced after it has completed.

This will allow these messages to be published after the resource
they're referencing has been persisted, guaranteeing that it will be available
when fetched by other message handlers.

Note that this is not a full solution; it's not uncommon for components
to call other components directly, and this decorator will not change those
references in place. As is, it will only apply the messages produced within a
function by the specified component.