### PR TITLE
Generalize SNS and SQS support for LocalStack

### DIFF
--- a/docs/LOCALSTACK.md
+++ b/docs/LOCALSTACK.md
@@ -1,0 +1,60 @@
+# LocalStack
+
+SNS and SQS interactions can be tested with [LocalStack](https://github.com/atlassian/localstack).
+
+Here's how:
+
+ 1. Run `LocalStack`
+
+    The easiest way is via Docker:
+
+        docker run -it --rm --name localstack -p 4567-4578:4567-4578 -p 8080:8080 atlassianlabs/localstack
+
+ 2. Provision a topic and queue using the [AWS CLI](https://aws.amazon.com/cli/)
+
+        # create a topic
+        aws --endpoint-url http://localhost:4575 sns create-topic --name mytopic
+
+        # create a queue
+        aws --endpoint-url http://localhost:4576 sqs create-queue --queue-name myqueue
+
+        # subscribe the queue to the topic
+        aws --endpoint-url http://localhost:4575 sns subscribe \
+            --topic-arn arn:aws:sns:us-east-1:123456789012:mytopic \
+            --protocol sqs \
+            --notification-endpoint arn:aws:sqs:us-east-1:123456789012:myqueue
+
+    Note that `LocalStack` currently does not validate the `notification-endpoint` correctly; a malformed
+    input (such as a queue `url`) will result in errors when publishing to the topic.
+
+ 3. Configure the object graph.
+
+    You will need to specify your queue url, you topic ARN, and the `LocalStack` API endpoints. You will
+    also need to inform `microcosm-pubsub` that you are using `LocalStack` because the message body it creates
+    for subscribed queues does not match what AWS does.
+
+    Example:
+
+        from microcosm.api import create_object_graph
+        from microcosm.loaders import load_from_dict
+
+        loader = load_from_dict(
+            sqs_consumer=dict(
+                endpoint_url="http://localhost:4576",
+                sqs_queue_url="http://localhost:4576/123456789012/myqueue",
+            ),
+            sqs_envelope=dict(
+                strategy_name="LocalStackSQSEnvelope",
+            ),
+            sns_producer=dict(
+                endpoint_url="http://localhost:4575",
+            ),
+            sns_topic_arns=dict(
+                default="arn:aws:sns:us-east-1:123456789012:mytopic",
+            ),
+        )
+        graph = create_object_graph("test", loader=loader)
+        graph.use(
+            "sqs_consumer",
+            "sns_producer",
+        )

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -72,6 +72,7 @@ class SQSConsumer(object):
 
 
 @defaults(
+    endpoint_url=None,
     # SQS will not return more than ten messages at a time
     limit=10,
     # SQS will only return a few messages at time unless long polling is enabled (>0)
@@ -99,7 +100,8 @@ def configure_sqs_consumer(graph):
         from mock import MagicMock
         sqs_client = MagicMock()
     else:
-        sqs_client = client("sqs")
+        endpoint_url = graph.config.sqs_consumer.endpoint_url
+        sqs_client = client("sqs", endpoint_url=endpoint_url)
 
     return SQSConsumer(
         sqs_client=sqs_client,

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -191,6 +191,7 @@ def configure_sns_topic_arns(graph):
 
 
 @defaults(
+    endpoint_url=None,
     mock_sns=True,
     skip=None,
 )
@@ -213,8 +214,8 @@ def configure_sns_producer(graph):
 
         sns_client = MagicMock()
     else:
-        sns_client = client("sns")
-
+        endpoint_url = graph.config.sns_producer.endpoint_url
+        sns_client = client("sns", endpoint_url=endpoint_url)
     try:
         opaque = graph.opaque
     except NotBoundError:

--- a/microcosm_pubsub/tests/test_envelope.py
+++ b/microcosm_pubsub/tests/test_envelope.py
@@ -1,0 +1,102 @@
+"""
+SQS envelope tests.
+
+"""
+from json import dumps
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+
+from microcosm.api import create_object_graph
+from microcosm_pubsub.conventions import created
+from microcosm_pubsub.envelope import (
+    CodecSQSEnvelope,
+    LocalStackSQSEnvelope,
+    RawSQSEnvelope,
+)
+
+
+def test_raw_sqs_envelope():
+    graph = create_object_graph("example", testing=True)
+    consumer = None
+    message_id = "message_id"
+    receipt_handle = "receipt_handle"
+    envelope = RawSQSEnvelope(graph)
+
+    sqs_message = envelope.parse_raw_message(consumer, dict(
+        MessageId=message_id,
+        ReceiptHandle=receipt_handle,
+        Body=dict(
+            foo="bar",
+        ),
+    ))
+
+    assert_that(sqs_message.content, is_(equal_to(dict(foo="bar"))))
+    assert_that(sqs_message.media_type, is_(equal_to("application/json")))
+    assert_that(sqs_message.message_id, is_(equal_to(message_id)))
+    assert_that(sqs_message.receipt_handle, is_(equal_to(receipt_handle)))
+
+
+def test_codec_sqs_envelope():
+    graph = create_object_graph("example", testing=True)
+    consumer = None
+    message_id = "message_id"
+    receipt_handle = "receipt_handle"
+    envelope = CodecSQSEnvelope(graph)
+
+    media_type = created("foo")
+    uri = "http://foo/id"
+
+    sqs_message = envelope.parse_raw_message(consumer, dict(
+        MessageId=message_id,
+        ReceiptHandle=receipt_handle,
+        Body=dumps(dict(
+            Message=dumps(dict(
+                mediaType=media_type,
+                foo="bar",
+                uri=uri,
+            )),
+        )),
+    ))
+
+    assert_that(sqs_message.content, is_(equal_to(dict(
+        # NB: no foo key here because it's not part of the schema
+        media_type=media_type,
+        uri=uri,
+    ))))
+    assert_that(sqs_message.media_type, is_(equal_to(media_type)))
+    assert_that(sqs_message.message_id, is_(equal_to(message_id)))
+    assert_that(sqs_message.receipt_handle, is_(equal_to(receipt_handle)))
+
+
+def test_localstack_sqs_envealope():
+    graph = create_object_graph("example", testing=True)
+    consumer = None
+    message_id = "message_id"
+    receipt_handle = "receipt_handle"
+    envelope = LocalStackSQSEnvelope(graph)
+
+    media_type = created("foo")
+    uri = "http://foo/id"
+
+    sqs_message = envelope.parse_raw_message(consumer, dict(
+        MessageId=message_id,
+        ReceiptHandle=receipt_handle,
+        Body=dumps(dict(
+            mediaType=media_type,
+            foo="bar",
+            uri=uri,
+        )),
+    ))
+
+    assert_that(sqs_message.content, is_(equal_to(dict(
+        # NB: no foo key here because it's not part of the schema
+        media_type=media_type,
+        uri=uri,
+    ))))
+    assert_that(sqs_message.media_type, is_(equal_to(media_type)))
+    assert_that(sqs_message.message_id, is_(equal_to(message_id)))
+    assert_that(sqs_message.receipt_handle, is_(equal_to(receipt_handle)))


### PR DESCRIPTION
 -  Add `endpoint_url` to boto3 client creation
 -  Generalize envelope parsing to support LocalStack encoding