### PR TITLE
Extract approximate receive count on SQS receive

### DIFF
--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -36,8 +36,11 @@ class SQSConsumer(object):
         return [
             self.sqs_envelope.parse_raw_message(self, raw_message)
             for raw_message in self.sqs_client.receive_message(
-                QueueUrl=self.sqs_queue_url,
+                AttributeNames=[
+                    "ApproximateReceiveCount",
+                ],
                 MaxNumberOfMessages=self.limit,
+                QueueUrl=self.sqs_queue_url,
                 WaitTimeSeconds=self.wait_seconds,
             ).get("Messages", [])
         ]

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -2,7 +2,8 @@
 Message consumer.
 
 """
-from boto3 import client
+from boto3 import Session
+
 from microcosm.api import defaults
 
 
@@ -75,6 +76,8 @@ class SQSConsumer(object):
 
 
 @defaults(
+    profile_name=None,
+    region_name=None,
     endpoint_url=None,
     # SQS will not return more than ten messages at a time
     limit=10,
@@ -104,7 +107,14 @@ def configure_sqs_consumer(graph):
         sqs_client = MagicMock()
     else:
         endpoint_url = graph.config.sqs_consumer.endpoint_url
-        sqs_client = client("sqs", endpoint_url=endpoint_url)
+        profile_name = graph.config.sqs_consumer.profile_name
+        region_name = graph.config.sqs_consumer.region_name
+        session = Session(profile_name=profile_name)
+        sqs_client = session.client(
+            "sqs",
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+        )
 
     return SQSConsumer(
         sqs_client=sqs_client,

--- a/microcosm_pubsub/envelope.py
+++ b/microcosm_pubsub/envelope.py
@@ -119,6 +119,9 @@ class SQSEnvelope(MessageBodyParser, MediaTypeAndContentParser):
         """
         message_id = raw_message["MessageId"]
         receipt_handle = raw_message["ReceiptHandle"]
+        attributes = raw_message["Attributes"]
+        approximate_receive_count = attributes["ApproximateReceiveCount"]
+
         body = raw_message["Body"]
 
         if self.validate_md5:
@@ -133,6 +136,7 @@ class SQSEnvelope(MessageBodyParser, MediaTypeAndContentParser):
             media_type=media_type,
             message_id=message_id,
             receipt_handle=receipt_handle,
+            approximate_receive_count=approximate_receive_count,
         )
 
     def validate_md5(self, raw_message, body):

--- a/microcosm_pubsub/envelope.py
+++ b/microcosm_pubsub/envelope.py
@@ -119,8 +119,8 @@ class SQSEnvelope(MessageBodyParser, MediaTypeAndContentParser):
         """
         message_id = raw_message["MessageId"]
         receipt_handle = raw_message["ReceiptHandle"]
-        attributes = raw_message["Attributes"]
-        approximate_receive_count = attributes["ApproximateReceiveCount"]
+        attributes = raw_message.get("Attributes", {})
+        approximate_receive_count = attributes.get("ApproximateReceiveCount")
 
         body = raw_message["Body"]
 

--- a/microcosm_pubsub/main.py
+++ b/microcosm_pubsub/main.py
@@ -1,0 +1,117 @@
+"""
+PubSub CLI
+
+"""
+from __future__ import print_function
+from argparse import ArgumentParser
+
+from microcosm.api import create_object_graph
+from microcosm.loaders import load_from_dict
+
+from microcosm_pubsub.conventions import created
+
+
+def main():
+    args = parse_args()
+    args.func(args)
+
+
+def parse_args():
+    parser = ArgumentParser()
+
+    # common arguments
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--profile",
+    )
+    parser.add_argument(
+        "--region",
+    )
+
+    subparsers = parser.add_subparsers()
+    write_parser = subparsers.add_parser("write")
+    write_parser.add_argument(
+        "--topic-arn",
+        required=True,
+    )
+    write_parser.add_argument(
+        "--uri",
+        required=True,
+    )
+    write_parser.add_argument(
+        "--media-type",
+        required=True,
+    )
+    write_parser.set_defaults(func=write)
+
+    read_parser = subparsers.add_parser("read")
+    read_parser.add_argument(
+        "--queue-url",
+        required=True,
+    )
+    read_parser.add_argument(
+        "--nack",
+        action="store_true",
+    )
+    read_parser.add_argument(
+        "--nack-timeout",
+        default=1,
+        type=int,
+    )
+    read_parser.set_defaults(func=read)
+    return parser.parse_args()
+
+
+def write(args):
+    loader = load_from_dict(
+        sns_producer=dict(
+            profile_name=args.profile,
+            region_name=args.region,
+        ),
+        sns_topic_arns=dict(
+            default=args.topic_arn,
+        ),
+    )
+
+    graph = create_object_graph("pubsub", debug=args.debug, loader=loader)
+    graph.use("pubsub_message_schema_registry")
+    graph.use("sns_topic_arns")
+    graph.use("sns_producer")
+    graph.lock()
+
+    if args.media_type.startswith("application"):
+        media_type = args.media_type
+    else:
+        media_type = created(args.media_type)
+
+    message_id = graph.sns_producer.produce(
+        media_type=media_type,
+        uri=args.uri,
+    )
+    print("Wrote SNS message: {}".format(message_id))  # noqa
+
+
+def read(args):
+    loader = load_from_dict(
+        sqs_consumer=dict(
+            profile_name=args.profile,
+            region_name=args.region,
+            sqs_queue_url=args.queue_url,
+        ),
+    )
+    graph = create_object_graph("pubsub", debug=args.debug, loader=loader)
+    graph.use("sqs_consumer")
+    graph.lock()
+
+    for message in graph.sqs_consumer.consume():
+        print("Read SQS message: {} ({})".format(  # noqa
+            message.message_id,
+            message.approximate_receive_count,
+        ))
+        if args.nack:
+            message.nack(args.nack_timeout)
+        else:
+            message.ack()

--- a/microcosm_pubsub/message.py
+++ b/microcosm_pubsub/message.py
@@ -10,12 +10,19 @@ class SQSMessage(object):
     SQS message wrapper.
 
     """
-    def __init__(self, consumer, content, media_type, message_id, receipt_handle):
+    def __init__(self,
+                 consumer,
+                 content,
+                 media_type,
+                 message_id,
+                 receipt_handle,
+                 approximate_receive_count=None):
         self.consumer = consumer
         self.content = content
         self.media_type = media_type
         self.message_id = message_id
         self.receipt_handle = receipt_handle
+        self.approximate_receive_count = approximate_receive_count
 
     def ack(self):
         """

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -7,7 +7,7 @@ from distutils.util import strtobool
 from functools import wraps
 from six import string_types
 
-from boto3 import client
+from boto3 import Session
 from microcosm.api import defaults
 from microcosm.errors import NotBoundError
 from microcosm_logging.decorators import logger
@@ -191,6 +191,8 @@ def configure_sns_topic_arns(graph):
 
 
 @defaults(
+    profile_name=None,
+    region_name=None,
     endpoint_url=None,
     mock_sns=True,
     skip=None,
@@ -215,7 +217,14 @@ def configure_sns_producer(graph):
         sns_client = MagicMock()
     else:
         endpoint_url = graph.config.sns_producer.endpoint_url
-        sns_client = client("sns", endpoint_url=endpoint_url)
+        profile_name = graph.config.sns_producer.profile_name
+        region_name = graph.config.sns_producer.region_name
+        session = Session(profile_name=profile_name)
+        sns_client = session.client(
+            "sns",
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+        )
     try:
         opaque = graph.opaque
     except NotBoundError:

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -44,6 +44,9 @@ def test_consume():
 
     # SQS should have been called
     graph.sqs_consumer.sqs_client.receive_message.assert_called_with(
+        AttributeNames=[
+            "ApproximateReceiveCount",
+        ],
         QueueUrl="queue",
         MaxNumberOfMessages=10,
         WaitTimeSeconds=1,

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,12 @@ setup(
     dependency_links=[
     ],
     entry_points={
+        "console_scripts": [
+            "pubsub = microcosm_pubsub.main:main",
+        ],
         "microcosm.factories": [
-            "sqs_message_context = microcosm_pubsub.context:configure_sqs_message_context",
             "pubsub_message_schema_registry = microcosm_pubsub.registry:configure_schema_registry",
+            "sqs_message_context = microcosm_pubsub.context:configure_sqs_message_context",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",
             "sqs_envelope = microcosm_pubsub.envelope:configure_sqs_envelope",
             "sqs_message_dispatcher = microcosm_pubsub.dispatcher:configure",


### PR DESCRIPTION
We can use this count for backoff purposes.

It's documented as being approximate, but it seems to be accurate empirically. 

I also added (back) a CLI for testing pubsub using standard conventions:

```
# write a message; note that the SNS id is different from the SQS id
> pubsub write --topic-arn $TOPIC --uri http://example.com --media-type example
Wrote SNS message: 59d07afd-0e38-5f2b-8708-2b17e094ce1d

# read the same message back; the parenthetical includes the read count
> pubsub read --queue-url $QUEUE --nack
Read SQS message: 67859b2d-94e3-43c5-8d11-a863796901f3 (1)

> pubsub read --queue-url $QUEUE --nack
Read SQS message: 67859b2d-94e3-43c5-8d11-a863796901f3 (2)

> pubsub read --queue-url $QUEUE --nack
Read SQS message: 67859b2d-94e3-43c5-8d11-a863796901f3 (3)

> pubsub read --queue-url $QUEUE --nack
Read SQS message: 67859b2d-94e3-43c5-8d11-a863796901f3 (4)
```
