### PR TITLE
Allow daemons to run from a file URL and playback data files.

### DIFF
--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -94,5 +94,6 @@ class ConsumerDaemon(Daemon):
         return super(ConsumerDaemon, cls).create_for_testing(
             sqs_queue_url="queue",
             loader=loader,
+            envelope=None,
             **kwargs
         )

--- a/microcosm_pubsub/envelope.py
+++ b/microcosm_pubsub/envelope.py
@@ -130,7 +130,7 @@ class SQSEnvelope(MessageBodyParser, MediaTypeAndContentParser):
         Create an `SQSMessage` from SQS data.
 
         """
-        message_id = self.parse_message(raw_message)
+        message_id = self.parse_message_id(raw_message)
         receipt_handle = self.parse_receipt_handle(raw_message)
         attributes = raw_message.get("Attributes", {})
         approximate_receive_count = attributes.get("ApproximateReceiveCount")

--- a/microcosm_pubsub/reader.py
+++ b/microcosm_pubsub/reader.py
@@ -1,0 +1,39 @@
+"""
+Implement SQS message reading from other sources.
+
+"""
+from json import loads
+
+from microcosm_daemon.error_policy import FatalError
+
+
+class SQSFileReader(object):
+    """
+    Read message data from a file.
+
+    """
+    def __init__(self, path):
+        self.path = path
+        self.iter_ = iter(open(self.path))
+
+    def receive_message(self, MaxNumberOfMessages, **kwargs):
+        limit = MaxNumberOfMessages
+
+        messages = []
+        for _ in range(limit):
+            try:
+                message = next(self.iter_)
+            except StopIteration:
+                break
+            else:
+                messages.append(loads(message))
+
+        if not messages:
+            raise FatalError("No more messages to replay")
+        return dict(Messages=messages)
+
+    def delete_message(self, *args, **kwargs):
+        pass
+
+    def change_message_visibility(self, *args, **kwargs):
+        pass


### PR DESCRIPTION
This PR includes two new features:

 1. If the `--sqs-queue-url` points to a file, construct a simulated SQS client
    that reads JSON lines from a file until done.

 2. If the `NaiveSQSEnvelope` is used, allow a flat dictionary to be used for inputs
    (e.g. just `mediaType` and `uri`); this may be specified from the command line.

The net effect is that you can create `/path/to/file` with:

```
   {"mediaType": "some-media-type", "uri": "http://some-uri"}
   {"mediaType": "some-media-type", "uri": "http://some-uri"}
   {"mediaType": "some-media-type", "uri": "http://some-uri"}
   {"mediaType": "some-media-type", "uri": "http://some-uri"}
```

And run:

    my-consumer-daemon --debug --sqs-queue-url /path/to/file --envelope NaiveSQSEnvelope

And replay all of the file's messages.