### PR TITLE
GLOB-15482 Add deferred batch producer and handler.

### DIFF
--- a/microcosm_pubsub/conventions.py
+++ b/microcosm_pubsub/conventions.py
@@ -7,7 +7,7 @@ from inspect import isclass
 from six import string_types
 
 from inflection import underscore
-from marshmallow import fields
+from marshmallow import fields, Schema
 
 from microcosm_pubsub.codecs import PubSubMessageSchema
 
@@ -147,3 +147,28 @@ def stopped(resource, **kwargs):
 
     """
     return make_media_type(resource, lifecycle_change=LifecycleChange.Stopped, **kwargs)
+
+
+class BatchedMessageSchema(Schema):
+    """
+    A wrapper for a single message that is to be published in a
+    MessageBatchSchema.
+
+    """
+    media_type = fields.String(required=True)
+    message = fields.Raw(required=True)
+    topic_arn = fields.String(required=True)
+    opaque_data = fields.Raw(required=True)
+
+
+class MessageBatchSchema(PubSubMessageSchema):
+    """
+    A message indicating that a batch of messages needs to be published.
+
+    """
+    MEDIA_TYPE = created("batch_message")
+
+    messages = fields.List(fields.Nested(BatchedMessageSchema), required=True)
+
+    def deserialize_media_type(self, obj):
+        return MessageBatchSchema.MEDIA_TYPE

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -78,10 +78,11 @@ class SQSMessageDispatcher(object):
                 self.logger.debug("Skipping message with no registered handler: {}".format(media_type))
                 return False
 
-            extra = dict(
+            extra = self.sqs_message_context(content)
+            extra.update(dict(
                 handler=titleize(handler.__class__.__name__),
                 uri=content.get("uri"),
-            )
+            ))
             with elapsed_time(extra):
                 result = self.invoke_handler(handler, media_type, content)
             self.logger.info(

--- a/microcosm_pubsub/handlers.py
+++ b/microcosm_pubsub/handlers.py
@@ -131,7 +131,7 @@ class URIHandler(object):
 @binding("publish_message_batch")
 @handles(created("BatchMessage"))
 @logger
-class PublishBatchMessage:
+class PublishBatchMessage(object):
 
     def __init__(self, graph):
         self.sns_producer = graph.sns_producer

--- a/microcosm_pubsub/handlers.py
+++ b/microcosm_pubsub/handlers.py
@@ -7,6 +7,10 @@ from inflection import titleize
 
 from requests import codes, get
 
+from microcosm.api import binding
+from microcosm_logging.decorators import logger
+from microcosm_pubsub.conventions import created
+from microcosm_pubsub.decorators import handles
 from microcosm_pubsub.errors import Nack
 
 
@@ -122,3 +126,22 @@ class URIHandler(object):
 
     def handle(self, message, uri, resource):
         return True
+
+
+@binding("publish_message_batch")
+@handles(created("BatchMessage"))
+@logger
+class PublishBatchMessage:
+
+    def __init__(self, graph):
+        self.sns_producer = graph.sns_producer
+
+    def __call__(self, message):
+        messages = message['messages']
+        for message in messages:
+            self.sns_producer.publish_message(
+                message["media_type"],
+                message["message"],
+                message["topic_arn"],
+                message["opaque_data"],
+            )

--- a/microcosm_pubsub/handlers.py
+++ b/microcosm_pubsub/handlers.py
@@ -137,7 +137,7 @@ class PublishBatchMessage:
         self.sns_producer = graph.sns_producer
 
     def __call__(self, message):
-        messages = message['messages']
+        messages = message["messages"]
         for message in messages:
             self.sns_producer.publish_message(
                 message["media_type"],

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -221,6 +221,8 @@ def configure_sns_topic_arns(graph):
         sns_topic_arns = dict()
     else:
         sns_topic_arns = defaultdict(lambda: graph.config.sns_topic_arns.default)
+        # NB: Do not use the default for the batch schema
+        sns_topic_arns[MessageBatchSchema.MEDIA_TYPE] = None
 
     sns_topic_arns.update(graph.config.sns_topic_arns.mappings)
 

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -19,7 +19,13 @@ import microcosm.opaque  # noqa
 
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.errors import TopicNotDefinedError
-from microcosm_pubsub.producer import deferred, DeferredProducer, iter_topic_mappings
+from microcosm_pubsub.producer import (
+    deferred,
+    deferred_batch,
+    DeferredProducer,
+    DeferredBatchProducer,
+    iter_topic_mappings,
+)
 from microcosm_pubsub.tests.fixtures import DerivedSchema
 
 
@@ -193,6 +199,65 @@ def test_deferred_production_decorator():
     foo = Foo(graph)
 
     func = deferred(foo)(foo.bar)
+    func()
+
+    assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))
+
+
+def test_deferred_batch_production():
+    """
+    Deferred production waits until the end of a block and publishes all
+    messages in one MessageBatchSchema
+
+    """
+    def loader(metadata):
+        return dict(
+            sns_topic_arns=dict(
+                default="topic",
+            )
+        )
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+    graph.use("opaque")
+
+    # set up response
+    graph.sns_producer.sns_client.publish.return_value = dict(MessageId=MESSAGE_ID)
+
+    with DeferredBatchProducer(graph.sns_producer) as producer:
+        assert_that(producer.produce(DerivedSchema.MEDIA_TYPE, data="data"), is_(none()))
+        assert_that(producer.produce(DerivedSchema.MEDIA_TYPE, data="data2"), is_(none()))
+        assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(0)))
+
+    assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))
+
+
+def test_batch_deferred_production_decorator():
+    """
+    Deferred production can be used to decorate a function
+
+    """
+    def loader(metadata):
+        return dict(
+            sns_topic_arns=dict(
+                default="topic",
+            )
+        )
+
+    class Foo:
+        def __init__(self, graph):
+            self.graph = graph
+            self.sns_producer = graph.sns_producer
+
+        def bar(self):
+            assert isinstance(self.sns_producer, DeferredBatchProducer)
+            self.sns_producer.produce(DerivedSchema.MEDIA_TYPE, data="data")
+            self.sns_producer.produce(DerivedSchema.MEDIA_TYPE, data="data2")
+            assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(0)))
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+    foo = Foo(graph)
+
+    func = deferred_batch(foo)(foo.bar)
     func()
 
     assert_that(graph.sns_producer.sns_client.publish.call_count, is_(equal_to(1)))

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -236,8 +236,7 @@ def test_deferred_batch_production():
 
 def test_publish_batch_with_no_topic_fails():
     """
-    Deferred production waits until the end of a block and publishes all
-    messages in one MessageBatchSchema
+    Require explicit configuration of a topic for batch messages.
 
     """
     def loader(metadata):


### PR DESCRIPTION
Why? For complicated routes, the deferred producer is insufficient for
avoiding NACKs caused by messages being published before a transaction
is committed. This adds a mechanism for batching messages that would be
published by a routed and republishing them from a daemon handler
*after* the transaction that wants to publish them is commited.