### PR TITLE
GLOB-15482 Log elapsed time with daemon handler execution.

### DIFF
--- a/microcosm_pubsub/handlers.py
+++ b/microcosm_pubsub/handlers.py
@@ -82,7 +82,7 @@ class URIHandler(object):
         )
 
     def on_handle(self, message, uri, resource):
-        self.logger.info(
+        self.logger.debug(
             "Handled {handler}",
             extra=dict(
                 handler=self.name,


### PR DESCRIPTION
Why? It's useful to know how long your handlers take when trying to tune
flows that can involve multiple handlers each making multiple http
requests.