### PR TITLE
Rework batch messages so they are added to the registry.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.41.0
+current_version = 0.41.1
 commit = False
 tag = False
 

--- a/microcosm_pubsub/batch.py
+++ b/microcosm_pubsub/batch.py
@@ -1,0 +1,31 @@
+from marshmallow import fields, Schema
+
+from microcosm_pubsub.conventions import created
+from microcosm_pubsub.codecs import PubSubMessageSchema
+from microcosm_pubsub.decorators import schema
+
+
+class BatchedMessageSchema(Schema):
+    """
+    A wrapper for a single message that is to be published in a
+    MessageBatchSchema.
+
+    """
+    media_type = fields.String(required=True)
+    message = fields.Raw(required=True)
+    topic_arn = fields.String(required=True)
+    opaque_data = fields.Raw(required=True)
+
+
+@schema
+class MessageBatchSchema(PubSubMessageSchema):
+    """
+    A message indicating that a batch of messages needs to be published.
+
+    """
+    MEDIA_TYPE = created("batch_message")
+
+    messages = fields.List(fields.Nested(BatchedMessageSchema), required=True)
+
+    def deserialize_media_type(self, obj):
+        return MessageBatchSchema.MEDIA_TYPE

--- a/microcosm_pubsub/conventions.py
+++ b/microcosm_pubsub/conventions.py
@@ -7,7 +7,7 @@ from inspect import isclass
 from six import string_types
 
 from inflection import underscore
-from marshmallow import fields, Schema
+from marshmallow import fields
 
 from microcosm_pubsub.codecs import PubSubMessageSchema
 
@@ -147,28 +147,3 @@ def stopped(resource, **kwargs):
 
     """
     return make_media_type(resource, lifecycle_change=LifecycleChange.Stopped, **kwargs)
-
-
-class BatchedMessageSchema(Schema):
-    """
-    A wrapper for a single message that is to be published in a
-    MessageBatchSchema.
-
-    """
-    media_type = fields.String(required=True)
-    message = fields.Raw(required=True)
-    topic_arn = fields.String(required=True)
-    opaque_data = fields.Raw(required=True)
-
-
-class MessageBatchSchema(PubSubMessageSchema):
-    """
-    A message indicating that a batch of messages needs to be published.
-
-    """
-    MEDIA_TYPE = created("batch_message")
-
-    messages = fields.List(fields.Nested(BatchedMessageSchema), required=True)
-
-    def deserialize_media_type(self, obj):
-        return MessageBatchSchema.MEDIA_TYPE

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -13,7 +13,8 @@ from microcosm.errors import NotBoundError
 from microcosm_logging.decorators import logger
 from microcosm_logging.timing import elapsed_time
 
-from microcosm_pubsub.conventions import LifecycleChange, make_media_type, MessageBatchSchema
+from microcosm_pubsub.batch import MessageBatchSchema
+from microcosm_pubsub.conventions import LifecycleChange, make_media_type
 from microcosm_pubsub.errors import TopicNotDefinedError
 
 

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -56,7 +56,8 @@ class PubSubMessageSchemaRegistry(object):
 
     def find(self, media_type):
         """
-        Create a codec or raise KeyError.
+        Create a codec or raise KeyError. If autoregistration is enabled, falls
+        back to the URIMessageSchema.
 
         """
         if media_type not in self._media_types:

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -17,7 +17,8 @@ from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_environ
 import microcosm.opaque  # noqa
 
-from microcosm_pubsub.conventions import created, MessageBatchSchema
+from microcosm_pubsub.batch import MessageBatchSchema
+from microcosm_pubsub.conventions import created
 from microcosm_pubsub.errors import TopicNotDefinedError
 from microcosm_pubsub.producer import (
     deferred,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "0.41.0"
+version = "0.41.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Why? If they are not in the registry the message batch handler will not be
able to properly parse these handlers as it will fall back to use the
URIPubSubMessage Codec and ommit fields.