### PR TITLE
Add NaiveMessage Autogeneration CLI.

### DIFF
--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -9,7 +9,10 @@ from boto3 import Session
 from microcosm.api import defaults
 
 from microcosm_pubsub.backoff import BackoffPolicy
-from microcosm_pubsub.reader import SQSFileReader
+from microcosm_pubsub.reader import SQSFileReader, SQSStdInReader
+
+
+STDIN = "STDIN"
 
 
 def is_file(url):
@@ -129,6 +132,8 @@ def configure_sqs_consumer(graph):
     if graph.metadata.testing or sqs_queue_url == "test":
         from mock import MagicMock
         sqs_client = MagicMock()
+    elif sqs_queue_url == STDIN:
+        sqs_client = SQSStdInReader()
     elif is_file(sqs_queue_url):
         sqs_client = SQSFileReader(sqs_queue_url)
     else:

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -44,7 +44,6 @@ class ConsumerDaemon(Daemon):
     @property
     def defaults(self):
         config = dict()
-        print(self.args)
 
         if self.args.stdin:
             config.update(

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -6,7 +6,8 @@ from microcosm.loaders import load_each, load_from_dict
 from microcosm_daemon.api import SleepNow
 from microcosm_daemon.daemon import Daemon
 
-from microcosm_pubsub.envelope import SQSEnvelope
+from microcosm_pubsub.envelope import SQSEnvelope, NaiveSQSEnvelope
+from microcosm_pubsub.consumer import STDIN
 
 
 class ConsumerDaemon(Daemon):
@@ -17,6 +18,7 @@ class ConsumerDaemon(Daemon):
 
     def make_arg_parser(self):
         parser = super(ConsumerDaemon, self).make_arg_parser()
+        parser.add_argument("--stdin", action="store_true")
         parser.add_argument("--sqs-queue-url")
         parser.add_argument("--envelope", choices=[
             envelope_cls.__name__
@@ -42,6 +44,17 @@ class ConsumerDaemon(Daemon):
     @property
     def defaults(self):
         config = dict()
+        print(self.args)
+
+        if self.args.stdin:
+            config.update(
+                sqs_envelope=dict(
+                    strategy_name=NaiveSQSEnvelope.__name__,
+                ),
+                sqs_consumer=dict(
+                    sqs_queue_url=STDIN,
+                ),
+            )
 
         if self.args.sqs_queue_url:
             config.update(
@@ -95,5 +108,6 @@ class ConsumerDaemon(Daemon):
             sqs_queue_url="queue",
             loader=loader,
             envelope=None,
+            stdin=False,
             **kwargs
         )

--- a/microcosm_pubsub/main.py
+++ b/microcosm_pubsub/main.py
@@ -4,11 +4,12 @@ PubSub CLI
 """
 from __future__ import print_function
 from argparse import ArgumentParser
+from json import dumps
 
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_dict
 
-from microcosm_pubsub.conventions import created
+from microcosm_pubsub.conventions import created, changed
 
 
 def main():
@@ -115,3 +116,23 @@ def read(args):
             message.nack(args.nack_timeout)
         else:
             message.ack()
+
+
+def make_naive_message():
+    parser = ArgumentParser()
+
+    parser.add_argument(
+        "--action",
+        choices=["created", "updated"],
+    )
+    parser.add_argument(
+        "--resource-name",
+    )
+    parser.add_argument(
+        "--uri",
+    )
+    args = parser.parse_args()
+
+    action = dict(created=created, changed=changed)[args.action]
+
+    print(dumps(dict(mediaType=action(args.resource_name), uri=args.uri)))

--- a/microcosm_pubsub/main.py
+++ b/microcosm_pubsub/main.py
@@ -5,6 +5,7 @@ PubSub CLI
 from __future__ import print_function
 from argparse import ArgumentParser
 from json import dumps
+from sys import stdout
 
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_dict
@@ -123,7 +124,7 @@ def make_naive_message():
 
     parser.add_argument(
         "--action",
-        choices=["created", "updated"],
+        choices=["created", "changed"],
     )
     parser.add_argument(
         "--resource-name",
@@ -135,4 +136,4 @@ def make_naive_message():
 
     action = dict(created=created, changed=changed)[args.action]
 
-    print(dumps(dict(mediaType=action(args.resource_name), uri=args.uri)))
+    stdout.write(dumps(dict(mediaType=action(args.resource_name), uri=args.uri)))

--- a/microcosm_pubsub/reader.py
+++ b/microcosm_pubsub/reader.py
@@ -53,7 +53,6 @@ class SQSStdInReader:
             message = stdin.readline()
             if message == "":
                 break
-            print("appending: {}".format(message))
             messages.append(loads(message))
 
         if not messages:

--- a/microcosm_pubsub/reader.py
+++ b/microcosm_pubsub/reader.py
@@ -2,6 +2,7 @@
 Implement SQS message reading from other sources.
 
 """
+from sys import stdin
 from json import loads
 
 from microcosm_daemon.error_policy import ExitError
@@ -27,6 +28,33 @@ class SQSFileReader:
                 break
             else:
                 messages.append(loads(message))
+
+        if not messages:
+            raise ExitError("No more messages to replay")
+        return dict(Messages=messages)
+
+    def delete_message(self, *args, **kwargs):
+        pass
+
+    def change_message_visibility(self, *args, **kwargs):
+        pass
+
+
+class SQSStdInReader:
+    """
+    Read message data from stdin.
+
+    """
+    def receive_message(self, MaxNumberOfMessages, **kwargs):
+        limit = MaxNumberOfMessages
+
+        messages = []
+        for _ in range(limit):
+            message = stdin.readline()
+            if message == "":
+                break
+            print("appending: {}".format(message))
+            messages.append(loads(message))
 
         if not messages:
             raise ExitError("No more messages to replay")

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
+            "make-naive-message = microcosm_pubsub.main:make_naive_message",
             "pubsub = microcosm_pubsub.main:main",
         ],
         "microcosm.factories": [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "make-naive-message = microcosm_pubsub.main:make_naive_message",
+            "publish-naive = microcosm_pubsub.main:make_naive_message",
             "pubsub = microcosm_pubsub.main:main",
         ],
         "microcosm.factories": [


### PR DESCRIPTION
Why? The NaiveMessage format and the file sqs url are awesome for making
it easier to test daemons locally, but they require looking up the
format for the NaiveMessage envelop when they can easily be constructed
by variables a develop is more likely to know. Sample usage:

```
 make-naive-message --action created --resource MyResource --uri uri | my-daemon --debug --stdin
```