### PR TITLE
Guard against repeated media type handlers

### DIFF
--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -115,6 +115,21 @@ class SQSMessageHandlerRegistry(object):
             if handler in bound_components or handler in bound_component_types
         }
 
+        media_type_handlers = {}
+        for media_type, handler in self.iter_handlers():
+            if handler in bound_components or handler in bound_component_types:
+                if media_type in media_type_handlers:
+                    raise AlreadyRegisteredError(
+                        "Handler {} already registered for media type: {}".format(
+                            handler.__name__,
+                            media_type,
+                        )
+                    )
+
+                media_type_handlers[media_type] = handler
+
+        return media_type_handlers
+
     def find(self, media_type, bound_handlers):
         handler = bound_handlers[media_type]
 

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -109,11 +109,6 @@ class SQSMessageHandlerRegistry(object):
             type(bound_component)
             for bound_component in bound_components
         ]
-        return {
-            media_type: handler
-            for media_type, handler in self.iter_handlers()
-            if handler in bound_components or handler in bound_component_types
-        }
 
         media_type_handlers = {}
         for media_type, handler in self.iter_handlers():


### PR DESCRIPTION
Report attempts to register multiple handlers for a for given media type.

Daemons will otherwise fail silently and pick only a single handler on
initialization.

We could ostensibly handle the same pubsub message multiple times within the same daemon, but it's probably preferred not to.