### PR TITLE
Add reason parameter to Nack

### DIFF
--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -77,7 +77,6 @@ class SQSMessageDispatcher:
                 # no handlers
                 self.logger.debug("Skipping message with no registered handler: {}".format(media_type))
                 return False
-
             extra = self.sqs_message_context(content)
             extra.update(dict(
                 handler=titleize(handler.__class__.__name__),
@@ -113,12 +112,15 @@ class SQSMessageDispatcher:
                 extra=extra,
             )
             return False
-        except Nack:
+        except Nack as nack:
+            extra = self.sqs_message_context(content)
+            extra.update(nack.extra)
             logger.info(
-                "Nacking SQS message: {}".format(
-                    media_type,
+                "Nacking SQS message {media_type} for reason: {reason}".format(
+                    media_type=media_type,
+                    reason=str(nack),
                 ),
-                extra=self.sqs_message_context(content)
+                extra=extra,
             )
             raise
         except Exception as error:

--- a/microcosm_pubsub/errors.py
+++ b/microcosm_pubsub/errors.py
@@ -13,7 +13,9 @@ class Nack(Exception):
     An error that causes the current message to be nacked.
 
     """
-    def __init__(self, visibility_timeout_seconds):
+    def __init__(self,  visibility_timeout_seconds, reason=None, extra=None):
+        super().__init__(reason)
+        self.extra = extra or dict()
         self.visibility_timeout_seconds = visibility_timeout_seconds
 
     def __repr__(self):


### PR DESCRIPTION
- add reason parameter to Nack

Why?

Eliminates need to log an extra event noting the nack reason.