### PR TITLE
Skip message production in DeferredProducer during testing

### DIFF
--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -101,6 +101,9 @@ class DeferredProducer:
         self.messages = []
 
     def produce(self, media_type, dct=None, **kwargs):
+        if self.producer.skip:
+            return
+
         message, topic_arn, opaque_data = self.producer.create_message(media_type, dct, **kwargs)
         self.messages.append((media_type, message, topic_arn, opaque_data))
 


### PR DESCRIPTION
This otherwise causes local testing apps to try and publish to
nonexistent queues