### PR TITLE
Add introspection to sns_producer

### DIFF
--- a/microcosm_pubsub/conventions/publish_info/convention.py
+++ b/microcosm_pubsub/conventions/publish_info/convention.py
@@ -1,0 +1,33 @@
+"""
+Publish Info convention.
+
+"""
+from microcosm_flask.conventions.base import EndpointDefinition
+from microcosm_flask.conventions.crud import configure_crud
+from microcosm_flask.operations import Operation
+from microcosm_flask.namespaces import Namespace
+from microcosm_pubsub.conventions.publish_info.resources import (
+    PublishInfoSchema,
+    Schema,
+)
+
+
+def configure_publish_info(graph):
+    ns = Namespace(
+        subject="introspection/publish_info",
+    )
+
+    def search(**kwargs):
+        publish_info = list(graph.sns_producer.get_publish_info())
+        return publish_info, len(publish_info)
+
+    mappings = {
+        Operation.Search: EndpointDefinition(
+            func=search,
+            request_schema=Schema(),
+            response_schema=PublishInfoSchema(),
+        ),
+    }
+
+    configure_crud(graph, ns, mappings)
+    return ns

--- a/microcosm_pubsub/conventions/publish_info/resources.py
+++ b/microcosm_pubsub/conventions/publish_info/resources.py
@@ -1,0 +1,12 @@
+"""
+Publish Info resources.
+
+"""
+from marshmallow import fields, Schema
+
+
+class PublishInfoSchema(Schema):
+    mediaType = fields.String(attribute="media_type")
+    route = fields.String()
+    callModule = fields.String(attribute="call_module")
+    callFunction = fields.String(attribute="call_function")

--- a/microcosm_pubsub/conventions/publish_info/resources.py
+++ b/microcosm_pubsub/conventions/publish_info/resources.py
@@ -10,3 +10,4 @@ class PublishInfoSchema(Schema):
     route = fields.String()
     callModule = fields.String(attribute="call_module")
     callFunction = fields.String(attribute="call_function")
+    count = fields.Integer()

--- a/microcosm_pubsub/models.py
+++ b/microcosm_pubsub/models.py
@@ -1,0 +1,31 @@
+"""
+Microcosm Pubsub Models
+
+"""
+
+
+class SNSIntrospection(object):
+    def __init__(
+        self,
+        media_type,
+        route,
+        call_module,
+        call_function,
+    ):
+        self.media_type = media_type
+        self.route = route
+        self.call_module = call_module
+        self.call_function = call_function
+
+    def __hash__(self):
+        return hash((self.media_type, self.route, self.call_module, self.call_function))
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return all((
+            self.media_type == other.media_type,
+            self.route == other.route,
+            self.call_module == other.call_module,
+            self.call_function == other.call_function,
+        ))

--- a/microcosm_pubsub/models.py
+++ b/microcosm_pubsub/models.py
@@ -11,21 +11,10 @@ class SNSIntrospection(object):
         route,
         call_module,
         call_function,
+        count,
     ):
         self.media_type = media_type
         self.route = route
         self.call_module = call_module
         self.call_function = call_function
-
-    def __hash__(self):
-        return hash((self.media_type, self.route, self.call_module, self.call_function))
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-        return all((
-            self.media_type == other.media_type,
-            self.route == other.route,
-            self.call_module == other.call_module,
-            self.call_function == other.call_function,
-        ))
+        self.count = count

--- a/microcosm_pubsub/tests/conventions/test_publish_info.py
+++ b/microcosm_pubsub/tests/conventions/test_publish_info.py
@@ -1,0 +1,63 @@
+"""
+Publish info convention tests.
+
+"""
+
+from hamcrest import (
+    assert_that,
+    equal_to,
+    is_,
+)
+from json import loads
+from microcosm.api import create_object_graph
+from microcosm_pubsub.tests.fixtures import DerivedSchema
+
+
+def test_publish_info():
+    """
+    Default publish info check returns OK.
+
+    """
+    def loader(metadata):
+        return dict(
+            sns_topic_arns=dict(
+                default="topic",
+            ),
+        )
+    graph = create_object_graph(name="example", testing=True, loader=loader)
+
+    # set up response
+    graph.sns_producer.sns_client.publish.return_value = dict(MessageId="message-id")
+
+    # graph.use("sns_producer")
+    graph.use("publish_info_convention")
+
+    # Publish two of the same message (testing to maintain a unique set of pubsub calls)
+    graph.sns_producer.produce(
+        media_type=DerivedSchema.MEDIA_TYPE,
+        data="test-uri"
+    )
+
+    graph.sns_producer.produce(
+        media_type=DerivedSchema.MEDIA_TYPE,
+        data="test-uri"
+    )
+
+    client = graph.flask.test_client()
+
+    response = client.get("/api/introspection/publish_info")
+    assert_that(response.status_code, is_(equal_to(200)))
+
+    decoded_response = loads(response.data.decode("utf-8"))
+    assert_that(
+        decoded_response["items"][0]["callFunction"],
+        is_(equal_to("test_publish_info")),
+    )
+    assert_that(
+        decoded_response["items"][0]["mediaType"],
+        is_(equal_to(DerivedSchema.MEDIA_TYPE)),
+    )
+    assert_that(
+        decoded_response["count"],
+        is_(equal_to(1)),
+    )

--- a/microcosm_pubsub/tests/conventions/test_publish_info.py
+++ b/microcosm_pubsub/tests/conventions/test_publish_info.py
@@ -58,6 +58,10 @@ def test_publish_info():
         is_(equal_to(DerivedSchema.MEDIA_TYPE)),
     )
     assert_that(
+        decoded_response["items"][0]["count"],
+        is_(equal_to(2)),
+    )
+    assert_that(
         decoded_response["count"],
         is_(equal_to(1)),
     )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "marshmallow>=2.15.0",
         "microcosm>=2.0.0",
         "microcosm-daemon>=1.0.0",
+        "microcosm-flask>=1.0.1",
         "microcosm-logging>=1.0.0",
     ],
     setup_requires=[
@@ -34,6 +35,7 @@ setup(
         "microcosm.factories": [
             "pubsub_message_schema_registry = microcosm_pubsub.registry:configure_schema_registry",
             "pubsub_lifecycle_change = microcosm_pubsub.conventions:LifecycleChange",
+            "publish_info_convention = microcosm_pubsub.conventions.publish_info.convention:configure_publish_info",
             "sqs_message_context = microcosm_pubsub.context:configure_sqs_message_context",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",
             "sqs_envelope = microcosm_pubsub.envelope:configure_sqs_envelope",


### PR DESCRIPTION
Manage list of media types and where they were called from.
self.media_types manages a unique set of media types and the call stack from which they were called

Do not merge