### PR TITLE
Add check to make sure uri is not None

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = False
 tag = False
 

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -38,6 +38,9 @@ class SNSProducer:
         self.publish_info = Counter()
 
     def route_from(self, uri, method):
+        if not uri:
+            return None
+
         appctx = _app_ctx_stack.top
         reqctx = _request_ctx_stack.top
         if reqctx is not None:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "1.3.0"
+version = "1.3.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Why?

We can publish messages without it