### PR TITLE
Fail gracefully if matched url is not found

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.1
+current_version = 1.3.2
 commit = False
 tag = False
 

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -333,8 +333,8 @@ def configure_sns_producer(graph):
         opaque = None
 
     try:
-        register = bool(graph.publish_info_convention)
-    except NotBoundError:
+        register = bool(graph._cache.__getitem__('publish_info_convention'))
+    except KeyError:
         register = False
 
     if graph.config.sns_producer.skip is None:

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -298,6 +298,7 @@ def configure_sns_topic_arns(graph):
     endpoint_url=None,
     mock_sns=True,
     skip=None,
+    register=True,
 )
 def configure_sns_producer(graph):
     """
@@ -332,10 +333,7 @@ def configure_sns_producer(graph):
     except NotBoundError:
         opaque = None
 
-    try:
-        register = bool(graph._cache.__getitem__('publish_info_convention'))
-    except KeyError:
-        register = False
+    register = graph.config.sns_producer.register
 
     if graph.config.sns_producer.skip is None:
         # In development mode, default to not publishing because there's typically

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -20,6 +20,7 @@ from inspect import stack, getmodule
 
 from flask.globals import _app_ctx_stack, _request_ctx_stack
 from werkzeug.urls import url_parse
+from werkzeug.exceptions import NotFound
 
 
 @logger
@@ -50,7 +51,10 @@ class SNSProducer:
         else:
             return None
         parsed_url = url_parse(uri)
-        matched_urls = url_adapter.match(parsed_url.path, method)
+        try:
+            matched_urls = url_adapter.match(parsed_url.path, method)
+        except NotFound:
+            return None
         return matched_urls[0] if matched_urls else None
 
     def introspect(self, media_type, call_stack, uri):

--- a/microcosm_pubsub/tests/conventions/test_publish_info.py
+++ b/microcosm_pubsub/tests/conventions/test_publish_info.py
@@ -25,12 +25,11 @@ def test_publish_info():
             ),
         )
     graph = create_object_graph(name="example", testing=True, loader=loader)
+    graph.use("publish_info_convention")
+    graph.use("sns_producer")
 
     # set up response
     graph.sns_producer.sns_client.publish.return_value = dict(MessageId="message-id")
-
-    # graph.use("sns_producer")
-    graph.use("publish_info_convention")
 
     # Publish two of the same message (testing to maintain a unique set of pubsub calls)
     graph.sns_producer.produce(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "1.3.1"
+version = "1.3.2"
 
 setup(
     name=project,


### PR DESCRIPTION
Why?

Sometimes the associated URI with a pubsub message may not resolve to an endpoint in the service. We should simply return none for the route value in case this occurs.