### PR TITLE
Handle url_adaptor not being defined

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.2
+current_version = 1.3.3
 commit = False
 tag = False
 

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -42,13 +42,15 @@ class SNSProducer:
         if not uri:
             return None
 
+        url_adapter = None
         appctx = _app_ctx_stack.top
         reqctx = _request_ctx_stack.top
         if reqctx is not None:
             url_adapter = reqctx.url_adapter
         elif appctx is not None:
             url_adapter = appctx.url_adapter
-        else:
+
+        if url_adapter is None:
             return None
         parsed_url = url_parse(uri)
         try:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "1.3.2"
+version = "1.3.3"
 
 setup(
     name=project,


### PR DESCRIPTION
Why?

There are cases where the pubsub message may not be called from a service
(i.e. when called from a daemon), in which case there may be an app or
request context but no url adaptor associated with it. In that case we
return None.