### PR TITLE
Chain: Change extracts_ to extract_

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.4
+current_version = 1.3.5
 commit = False
 tag = False
 

--- a/microcosm_pubsub/chain/context_decorators.py
+++ b/microcosm_pubsub/chain/context_decorators.py
@@ -4,7 +4,7 @@ from inspect import getfullargspec, ismethod, isfunction
 from microcosm_pubsub.chain.decorators import EXTRACTS, BINDS
 
 
-EXTRACTS_PREFIX = "extracts_"
+EXTRACT_PREFIX = "extract_"
 
 
 def get_from_context(context, func):
@@ -52,16 +52,16 @@ def save_to_context(context, func):
 def save_to_context_by_func_name(context, func):
     """
     Decorate a function - save to a context (dictionary) the function return value
-    if the function is not signed by EXTRACTS and it's name starts with "extracts_"
+    if the function is not signed by EXTRACTS and it's name starts with "extract_"
 
     """
     if (
         hasattr(func, EXTRACTS) or
         not hasattr(func, "__name__") or
-        not func.__name__.startswith(EXTRACTS_PREFIX)
+        not func.__name__.startswith(EXTRACT_PREFIX)
     ):
         return func
-    name = func.__name__[len(EXTRACTS_PREFIX):]
+    name = func.__name__[len(EXTRACT_PREFIX):]
 
     @wraps(func)
     def decorate(*args, **kwargs):

--- a/microcosm_pubsub/tests/chain/test_decorators.py
+++ b/microcosm_pubsub/tests/chain/test_decorators.py
@@ -63,14 +63,14 @@ class TestDecorators:
     def test_save_to_context_by_func_name(self):
         context = dict()
 
-        def extracts_arg(number):
+        def extract_arg(number):
             return number
 
-        def extracts_args(num1, num2):
+        def extract_args(num1, num2):
             return num1, num2
 
-        save_to_context_by_func_name(context, extracts_arg)(0)
-        save_to_context_by_func_name(context, extracts_args)(1, 2)
+        save_to_context_by_func_name(context, extract_arg)(0)
+        save_to_context_by_func_name(context, extract_args)(1, 2)
         assert_that(context, is_(equal_to(dict(arg=0, args=(1, 2)))))
 
     def test_get_from_context_multiple_args(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "1.3.4"
+version = "1.3.5"
 
 setup(
     name=project,


### PR DESCRIPTION
Chain function that starts with `extracts_` automatically  "extract" the result to the the context. But we prefer the `extract_` prefix.