### PR TITLE
URIHandler.resource_type: use isinstance

### DIFF
--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -123,7 +123,7 @@ class URIHandler:
             raise Nack(self.nack_timeout)
         response.raise_for_status()
         body = response.json()
-        if type(body) is self.resource_type:
+        if isinstance(body, self.resource_type):
             return body
         return self.resource_type(**body)
 


### PR DESCRIPTION
Prefer `isinstance` over is `type() is`