### PR TITLE
Advanced context decorators (#100)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.7
+current_version = 1.3.8
 commit = False
 tag = False
 

--- a/microcosm_pubsub/chain/chain.py
+++ b/microcosm_pubsub/chain/chain.py
@@ -4,6 +4,7 @@ from microcosm_pubsub.chain.context_decorators import (
     save_to_context,
     save_to_context_by_func_name,
     temporarily_replace_context_keys,
+    DEFAULT_ASSIGNED,
 )
 
 
@@ -33,6 +34,16 @@ class Chain:
             save_to_context,
             save_to_context_by_func_name,
         ]
+
+    @property
+    def context_decorators_assigned(self):
+        """
+        Tuple naming attributes that self.context_decorators attributes should keep
+        It should contain all attributes that set by relevant decorators
+        (such as @extracts)
+
+        """
+        return DEFAULT_ASSIGNED
 
     @property
     def new_context_type(self):
@@ -65,5 +76,5 @@ class Chain:
     def apply_decorators(self, context, link):
         decorated_link = link
         for decorator in self.context_decorators:
-            decorated_link = decorator(context, decorated_link)
+            decorated_link = decorator(context, decorated_link, self.context_decorators_assigned)
         return decorated_link

--- a/microcosm_pubsub/chain/decorators.py
+++ b/microcosm_pubsub/chain/decorators.py
@@ -1,5 +1,25 @@
+from inspect import ismethod
+from functools import wraps
+
+
 EXTRACTS = "_extracts"
 BINDS = "_binds"
+
+
+def to_function(callable_object):
+    """
+    In python, we can't use setattr on a method
+    We can instead wrap the method in a function.
+    This function will wrap only methods.
+
+    """
+    if not ismethod(callable_object):
+        return callable_object
+
+    @wraps(callable_object)
+    def decorated_method(*args, **kwargs):
+        return callable_object(*args, **kwargs)
+    return decorated_method
 
 
 def extracts(*extract):
@@ -12,8 +32,9 @@ def extracts(*extract):
 
     """
     def decorate(func):
-        setattr(func, EXTRACTS, extract)
-        return func
+        function = to_function(func)
+        setattr(function, EXTRACTS, extract)
+        return function
     return decorate
 
 
@@ -27,6 +48,7 @@ def binds(**binds):
 
     """
     def decorate(func):
-        setattr(func, BINDS, binds)
-        return func
+        function = to_function(func)
+        setattr(function, BINDS, binds)
+        return function
     return decorate

--- a/microcosm_pubsub/tests/chain/test_chain.py
+++ b/microcosm_pubsub/tests/chain/test_chain.py
@@ -5,7 +5,7 @@ from hamcrest import (
 )
 
 from microcosm_pubsub.chain import Chain
-from microcosm_pubsub.chain.decorators import extracts
+from microcosm_pubsub.chain.decorators import extracts, binds
 
 
 class TestChain:
@@ -54,6 +54,28 @@ class TestChain:
             Chain(
                 lambda arg: arg * 10,
             ),
+        )
+        assert_that(
+            chain(),
+            is_(equal_to(200)),
+        )
+
+    def test_chain_link_with_multiple_decorators(self):
+
+        @extracts("param")
+        class Extractor:
+            def __call__(self):
+                return 20
+
+        class Transformer:
+            @extracts("res")
+            def transform(self, arg):
+                return arg * 10
+
+        chain = Chain(
+            Extractor(),
+            binds(param="arg")(Transformer().transform),
+            lambda res: res,
         )
         assert_that(
             chain(),

--- a/microcosm_pubsub/tests/chain/test_decorators.py
+++ b/microcosm_pubsub/tests/chain/test_decorators.py
@@ -18,9 +18,25 @@ from microcosm_pubsub.chain.context_decorators import (
 class TestDecorators:
 
     def test_get_from_context(self):
-        context = dict(arg=123)
+        context = dict(arg=200)
         wrapped = get_from_context(context, lambda arg: arg)
-        assert_that(wrapped(), is_(123))
+        assert_that(wrapped(), is_(200))
+
+    def test_get_from_context_default_value(self):
+        def function(a, b=10):
+            return a + b
+
+        context = dict()
+        wrapped = get_from_context(context, function)
+        assert_that(calling(wrapped), raises(KeyError))
+
+        context = dict(a=190)
+        wrapped = get_from_context(context, function)
+        assert_that(wrapped(), is_(200))
+
+        context = dict(a=190, b=11)
+        wrapped = get_from_context(context, function)
+        assert_that(wrapped(), is_(201))
 
     def test_save_to_context(self):
         context = dict()
@@ -40,12 +56,46 @@ class TestDecorators:
         def extract_args(num1, num2):
             return num1, num2
 
+        @extracts("from_callable")
+        class CallableExtractor:
+            def __call__(self, number):
+                return number
+
+        class Extractor:
+            def method(self, number):
+                return number
+
+            @classmethod
+            def class_method(cls, number):
+                return number
+
+            @staticmethod
+            def static_method(number):
+                return number
+
+        wrapped_method = extracts("from_method")(Extractor().method)
+        wrapped_class_method = extracts("from_class_method")(Extractor().class_method)
+        wrapped_static_method = extracts("from_static_method")(Extractor().static_method)
+
         save_to_context(context, dont_extract)(-1)
         save_to_context(context, extract_arg)(0)
         save_to_context(context, extract_arg1_and_arg2)(1, 2)
         save_to_context(context, extract_args)(1, 2)
+        save_to_context(context, CallableExtractor())(3)
+        save_to_context(context, wrapped_method)(4)
+        save_to_context(context, wrapped_class_method)(5)
+        save_to_context(context, wrapped_static_method)(6)
 
-        assert_that(context, is_(equal_to(dict(arg=0, arg1=1, arg2=2, args=(1, 2)))))
+        assert_that(context, is_(equal_to(dict(
+            arg=0,
+            arg1=1,
+            arg2=2,
+            args=(1, 2),
+            from_callable=3,
+            from_method=4,
+            from_class_method=5,
+            from_static_method=6,
+        ))))
 
     def test_overriding_extracts(self):
         context = dict()
@@ -129,7 +179,7 @@ class TestDecorators:
 
         assert_that(wrapped(), is_(123))
 
-    def test_temporarily_replace_context_keys_wring_order(self):
+    def test_temporarily_replace_context_keys_wrong_order(self):
         context = dict(arg=123)
 
         func = binds(arg="param")(lambda param: param)
@@ -137,7 +187,7 @@ class TestDecorators:
         wrapped = temporarily_replace_context_keys(context, func)
         wrapped = get_from_context(context, wrapped)
 
-        assert_that(calling(wrapped), raises(TypeError))
+        assert_that(calling(wrapped), raises(KeyError))
 
     def test_temporarily_replace_missing_keys(self):
         context = dict()
@@ -148,3 +198,24 @@ class TestDecorators:
         wrapped = temporarily_replace_context_keys(context, wrapped)
 
         assert_that(calling(wrapped), raises(KeyError))
+
+    def test_multiple_decorators(self):
+        @extracts("res_obj")
+        class Extractor:
+            def __call__(self, arg):
+                return arg
+
+        @extracts("res_func")
+        def extractor(arg):
+            return arg
+
+        context = dict(arg=123)
+        wrapped_object = save_to_context(context, get_from_context(context, Extractor()))
+        wrapped_function = save_to_context(context, get_from_context(context, extractor))
+        wrapped_object()
+        wrapped_function()
+        assert_that(context, is_(equal_to(dict(
+            arg=123,
+            res_obj=123,
+            res_func=123,
+        ))))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "1.3.7"
+version = "1.3.8"
 
 setup(
     name=project,


### PR DESCRIPTION
Cherry-pick https://github.com/globality-corp/microcosm-pubsub/pull/100
* Handle 2 decorators edge cases (methods decorators and non function callables)
* `get_from_context` now supports default value function arguments