### PR TITLE
Chain usability improvements.

### DIFF
--- a/microcosm_pubsub/chain/__init__.py
+++ b/microcosm_pubsub/chain/__init__.py
@@ -1,3 +1,10 @@
 from microcosm_pubsub.chain.chain import Chain  # noqa: F401
 from microcosm_pubsub.chain.decorators import binds, extracts  # noqa: F401
-from microcosm_pubsub.chain.statements import extract, when, switch, try_chain, for_each  # noqa: F401
+from microcosm_pubsub.chain.statements import (  # noqa: F401
+    assign,
+    extract,
+    for_each,
+    when,
+    switch,
+    try_chain,
+)

--- a/microcosm_pubsub/chain/chain.py
+++ b/microcosm_pubsub/chain/chain.py
@@ -63,18 +63,28 @@ class Chain:
         context = context or self.new_context_type()
         context.update(kwargs)
 
-        # Allow self reference
-        if "context" not in context:
-            context.update(context=context)
-        elif context["context"] is not context:
-            raise ValueError("context should be set as context")
-
         for link in self.links:
-            res = self.apply_decorators(context, link)()
+            func = self.apply_decorators(context, link)
+            res = func()
+
         return res
+
+    def __len__(self):
+        return len(self.links)
 
     def apply_decorators(self, context, link):
         decorated_link = link
         for decorator in self.context_decorators:
             decorated_link = decorator(context, decorated_link, self.context_decorators_assigned)
         return decorated_link
+
+    @classmethod
+    def make(cls, *args, chain=None, links=None, **kwargs):
+        if chain is not None:
+            return chain
+        elif links is not None:
+            return cls(*links)
+        elif args:
+            return cls(*args)
+        else:
+            raise ValueError("Must define one of 'chain', 'links', or '*args'")

--- a/microcosm_pubsub/chain/context.py
+++ b/microcosm_pubsub/chain/context.py
@@ -1,4 +1,8 @@
 from collections import MutableMapping
+from itertools import chain
+
+
+CONTEXT = "context"
 
 
 class SafeContext(MutableMapping):
@@ -6,21 +10,33 @@ class SafeContext(MutableMapping):
     Dictionary that raises on overwriting keys.
 
     """
-
     def __init__(self, *args, **kwargs):
         self.store = dict(*args, **kwargs)
 
     def __getitem__(self, key):
+        # enable context self-references
+        if key == CONTEXT:
+            return self
         return self.store[key]
 
     def __setitem__(self, key, value):
+        # do not allow overwrite of context self-references
+        if key == CONTEXT:
+            raise ValueError("May not reassign 'context' key")
+
         if key in self.store:
             raise ValueError(f"Key '{key}' already set")
+
         self.store[key] = value
 
     def assign(self, key, value):
+        # do not allow overwrite of context self-references
+        if key == CONTEXT:
+            raise ValueError("May not reassign 'context' key")
+
         # Skip validation
         self.store[key] = value
+        return self
 
     def __delitem__(self, key):
         del self.store[key]
@@ -33,3 +49,41 @@ class SafeContext(MutableMapping):
 
     def __getattr__(self, key):
         return self[key]
+
+    def local(self, *args, **kwargs):
+        """
+        Create a locally scoped child context.
+
+        """
+        return ScopedSafeContext(self, *args, **kwargs)
+
+
+class ScopedSafeContext(SafeContext):
+    """
+    SafeContext that delegates reads to a parent context.
+
+    """
+    def __init__(self, parent, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.parent = parent
+
+    def __getitem__(self, key):
+        # enable context self-references
+        if key == CONTEXT:
+            return self
+
+        try:
+            return self.store[key]
+        except KeyError:
+            return self.parent[key]
+
+    def __setitem__(self, key, value):
+        if key in self.parent:
+            raise ValueError(f"Key '{key}' already set")
+        super().__setitem__(key, value)
+
+    def __iter__(self):
+        return chain(iter(self.store), iter(self.parent))
+
+    def __len__(self):
+        return len(self.store) + len(self.parent)

--- a/microcosm_pubsub/tests/chain/test_context.py
+++ b/microcosm_pubsub/tests/chain/test_context.py
@@ -1,6 +1,8 @@
 from hamcrest import (
     assert_that,
     calling,
+    contains,
+    has_length,
     is_,
     raises,
 )
@@ -8,7 +10,7 @@ from hamcrest import (
 from microcosm_pubsub.chain.context import SafeContext
 
 
-class TestChain:
+class TestSafeContext:
 
     def test_can_set(self):
         context = SafeContext()
@@ -19,4 +21,53 @@ class TestChain:
     def test_cannot_overwrite(self):
         context = SafeContext()
         context["arg"] = 20
-        assert_that(calling(context.update).with_args(arg=21), raises(ValueError))
+        assert_that(
+            calling(context.update).with_args(arg=21),
+            raises(ValueError),
+        )
+
+
+class TestScopedSafeContext:
+
+    def setup(self):
+        self.parent = SafeContext()
+        self.parent["arg"] = 20
+
+        self.context = self.parent.local()
+
+    def test_can_read_parent_arg(self):
+        assert_that(self.context["arg"], is_(20))
+        assert_that(self.context.arg, is_(20))
+
+    def test_cannot_overwrite_parent_arg(self):
+        assert_that(
+            calling(self.context.update).with_args(arg=21),
+            raises(ValueError),
+        )
+
+    def test_can_set_own_arg(self):
+        self.context["arg2"] = 42
+        assert_that(self.context["arg2"], is_(42))
+        assert_that(self.context.arg2, is_(42))
+
+    def test_cannot_overwrite_own_arg(self):
+        self.context["arg2"] = 42
+        assert_that(
+            calling(self.context.update).with_args(arg2=21),
+            raises(ValueError),
+        )
+
+    def test_union(self):
+        self.context["arg2"] = 42
+
+        assert_that(
+            self.context,
+            has_length(2),
+        )
+        assert_that(
+            list(self.context),
+            contains(
+                "arg2",
+                "arg",
+            ),
+        )


### PR DESCRIPTION
Make pubsub chains more usable (and more correct). Specifically:

 -  Ensure that `ForEachStatement` allows the same variable to be set in the context
    on each iteration by using an alternate version of the context that implements
    local scoping.

 -  Do not require `Chain` to be declared explicitly when it can be derived from
    statement context.

 -  Allow switch statement cases and try catch error cases to use a builder syntax.

 -  Allow variable extraction to be implemented using a more fluent builder style.

Example usage: https://github.com/globality-corp/frigg/pull/204/commits/924e387e78f24cc0ce09bcaf486d16826ad456a8