### PR TITLE
Allow URIHandler to use callable resource types

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.0
+current_version = 1.9.1
 commit = False
 tag = False
 

--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -127,7 +127,7 @@ class URIHandler:
         return response.json()
 
     def convert_resource(self, resource):
-        if isinstance(resource, self.resource_type):
+        if isinstance(self.resource_type, type) and isinstance(resource, self.resource_type):
             return resource
         return self.resource_type(**resource)
 

--- a/microcosm_pubsub/tests/handlers/test_uri_handler.py
+++ b/microcosm_pubsub/tests/handlers/test_uri_handler.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock
+
+from hamcrest import assert_that, equal_to, instance_of, is_
+
+from microcosm_pubsub.handlers import URIHandler
+
+
+class Baz:
+
+    def __init__(self, foo):
+        self.foo = foo
+
+
+class TestURIHandler:
+
+    def test_convert_resource(self):
+        graph = MagicMock()
+        handler = URIHandler(graph)
+
+        resource = handler.convert_resource(
+            dict(
+                foo="bar",
+            ),
+        )
+        assert_that(
+            resource,
+            is_(equal_to(
+                dict(
+                    foo="bar",
+                ),
+            )),
+        )
+
+    def test_convert_resource_custom_type(self):
+        graph = MagicMock()
+
+        class BazURIHandler(URIHandler):
+
+            @property
+            def resource_type(self):
+                return Baz
+
+        handler = BazURIHandler(graph)
+        resource = handler.convert_resource(
+            dict(
+                foo="bar",
+            ),
+        )
+
+        assert_that(
+            resource,
+            is_(instance_of(Baz)),
+        )
+        assert_that(
+            resource.foo,
+            is_(equal_to("bar")),
+        )
+
+    def test_convert_resource_custom_callable(self):
+        graph = MagicMock()
+
+        class BazURIHandler(URIHandler):
+
+            @property
+            def resource_type(self):
+                def make(**kwargs):
+                    return Baz(**kwargs)
+                return make
+
+        handler = BazURIHandler(graph)
+        resource = handler.convert_resource(
+            dict(
+                foo="bar",
+            ),
+        )
+
+        assert_that(
+            resource,
+            is_(instance_of(Baz)),
+        )
+        assert_that(
+            resource.foo,
+            is_(equal_to("bar")),
+        )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "1.9.0"
+version = "1.9.1"
 
 setup(
     name=project,


### PR DESCRIPTION
We need this if we want to have a resource type be constructed in a nested way:

```
@property
def resource_type(self):
    def make(items, **kwargs):
        return MyListType(
            items=[
                MyType(**item)
                for item in items
            ],
            **kwargs
        )
    return make
```