### PR TITLE
X-Request-TTL support

### DIFF
--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -3,7 +3,7 @@ Message context.
 
 """
 
-from microcosm.api import defaults
+from microcosm.api import defaults, typed
 
 
 def sqs_message_context(message_dct, **kwargs):
@@ -18,8 +18,8 @@ def sqs_message_context(message_dct, **kwargs):
 
 
 @defaults(
-    enable_ttl=True,
-    initial_ttl=32,
+    enable_ttl=typed(bool, default_value=True),
+    initial_ttl=typed(int, default_value=32),
 )
 def configure_sqs_message_context(graph):
     """

--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -3,6 +3,8 @@ Message context.
 
 """
 
+from microcosm.api import defaults
+
 
 def sqs_message_context(message_dct, **kwargs):
     context = message_dct.get("opaque_data", dict())
@@ -15,6 +17,10 @@ def sqs_message_context(message_dct, **kwargs):
     return context
 
 
+@defaults(
+    enable_ttl=True,
+    initial_ttl=32,
+)
 def configure_sqs_message_context(graph):
     """
     Configure the message context function which controls what data you want to associate

--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -4,6 +4,7 @@ Message context.
 """
 
 from microcosm.api import defaults, typed
+from microcosm.config.types import boolean
 
 
 def sqs_message_context(message_dct, **kwargs):
@@ -18,7 +19,7 @@ def sqs_message_context(message_dct, **kwargs):
 
 
 @defaults(
-    enable_ttl=typed(bool, default_value=True),
+    enable_ttl=typed(boolean, default_value=True),
     initial_ttl=typed(int, default_value=32),
 )
 def configure_sqs_message_context(graph):

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -27,7 +27,7 @@ class SQSMessageDispatcher:
         self.sqs_message_context = self._find_sqs_message_context(graph)
         self.sqs_message_handler_registry = graph.sqs_message_handler_registry
         self.enable_ttl = graph.config.sqs_message_context.enable_ttl
-        self.initial_ttl = int(graph.config.sqs_message_context.initial_ttl)
+        self.initial_ttl = graph.config.sqs_message_context.initial_ttl
 
     def _find_sqs_message_context(self, graph):
         try:

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -8,7 +8,7 @@ from inflection import titleize
 from microcosm.errors import NotBoundError
 from microcosm_logging.decorators import context_logger, logger
 
-from microcosm_pubsub.errors import Nack, SkipMessage
+from microcosm_pubsub.errors import Nack, SkipMessage, TTLExpired
 from microcosm_logging.timing import elapsed_time
 
 
@@ -26,6 +26,8 @@ class SQSMessageDispatcher:
         self.sqs_consumer = graph.sqs_consumer
         self.sqs_message_context = self._find_sqs_message_context(graph)
         self.sqs_message_handler_registry = graph.sqs_message_handler_registry
+        self.enable_ttl = graph.config.sqs_message_context.enable_ttl
+        self.initial_ttl = int(graph.config.sqs_message_context.initial_ttl)
 
     def _find_sqs_message_context(self, graph):
         try:
@@ -83,6 +85,17 @@ class SQSMessageDispatcher:
                 handler=titleize(handler.__class__.__name__),
                 uri=content.get("uri"),
             ))
+
+            if self.enable_ttl:
+                ttl = content.get("X-Request-TTL", self.initial_ttl) - 1
+                if ttl == -1:
+                    self.logger.warning(
+                        f"Error handling SQS message: {media_type} - TTL expired",
+                        extra=extra
+                    )
+                    raise TTLExpired(extra=extra)
+                content["X-Request-TTL"] = ttl
+
             with elapsed_time(extra):
                 result = self.invoke_handler(handler, media_type, content)
             self.logger.info(
@@ -120,7 +133,7 @@ class SQSMessageDispatcher:
                 ),
                 extra=self.sqs_message_context(content)
             )
-            raise
+            raise TTLExpired()
         except Exception as error:
             logger.warning(
                 "Error handling SQS message: {}".format(

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -91,7 +91,7 @@ class SQSMessageDispatcher:
                 if ttl == -1:
                     self.logger.warning(
                         f"Error handling SQS message: {media_type} - TTL expired",
-                        extra=extra
+                        extra=extra,
                     )
                     raise TTLExpired(extra=extra)
                 content["X-Request-TTL"] = ttl

--- a/microcosm_pubsub/errors.py
+++ b/microcosm_pubsub/errors.py
@@ -28,3 +28,13 @@ class SkipMessage(Exception):
     def __init__(self, reason, extra=None):
         super().__init__(reason)
         self.extra = extra or dict()
+
+
+class TTLExpired(Exception):
+    """
+    Control-flow exception to skip messages in infinte loop.
+
+    """
+    def __init__(self, reason=None, extra=None):
+        super().__init__(reason)
+        self.extra = extra or dict()

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -4,13 +4,16 @@ Dispatcher tests.
 """
 from hamcrest import (
     assert_that,
+    calling,
     equal_to,
     is_,
+    raises,
 )
 from mock import Mock
 
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.message import SQSMessage
+from microcosm_pubsub.errors import TTLExpired
 from microcosm_pubsub.tests.fixtures import (
     ExampleDaemon,
     DerivedSchema,
@@ -94,3 +97,83 @@ def test_handle_with_skipping():
         bound_handlers=daemon.bound_handlers,
     )
     assert_that(result, is_(equal_to(False)))
+
+
+def test_dispatcher_sets_ttl():
+    """
+    Test that the dispatcher handles a message and sets the context TTL if is not sets.
+
+    """
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+
+    content = dict()
+    sqs_message_context = Mock(return_value=dict())
+    with graph.opaque.initialize(sqs_message_context, content):
+        result = graph.sqs_message_dispatcher.handle_message(
+            message=SQSMessage(
+                consumer=None,
+                content=content,
+                media_type=DerivedSchema.MEDIA_TYPE,
+                message_id=MESSAGE_ID,
+                receipt_handle=None,
+            ),
+            bound_handlers=daemon.bound_handlers,
+        )
+
+    assert_that(result, is_(equal_to(True)))
+    sqs_message_context.assert_called_once_with(content)
+    assert_that(content, is_(equal_to({'X-Request-TTL': 31})))
+
+
+def test_dispatcher_updates_ttl():
+    """
+    Test that the dispatcher handles a message and updates the context TTL.
+
+    """
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+
+    content = {'X-Request-TTL': 10}
+    sqs_message_context = Mock(return_value=dict())
+    with graph.opaque.initialize(sqs_message_context, content):
+        result = graph.sqs_message_dispatcher.handle_message(
+            message=SQSMessage(
+                consumer=None,
+                content=content,
+                media_type=DerivedSchema.MEDIA_TYPE,
+                message_id=MESSAGE_ID,
+                receipt_handle=None,
+            ),
+            bound_handlers=daemon.bound_handlers,
+        )
+
+    assert_that(result, is_(equal_to(True)))
+    sqs_message_context.assert_called_once_with(content)
+    assert_that(content, is_(equal_to({'X-Request-TTL': 9})))
+
+
+def test_dispatcher_fails_for_zero_ttl():
+    """
+    Test that the dispatcher handles a message and updates the context TTL.
+
+    """
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+
+    content = {'X-Request-TTL': 0}
+    sqs_message_context = Mock(return_value=dict())
+    with graph.opaque.initialize(sqs_message_context, content):
+        assert_that(
+            calling(graph.sqs_message_dispatcher.handle_message).with_args(
+                message=SQSMessage(
+                    consumer=None,
+                    content=content,
+                    media_type=DerivedSchema.MEDIA_TYPE,
+                    message_id=MESSAGE_ID,
+                    receipt_handle=None,
+                ),
+                bound_handlers=daemon.bound_handlers,
+            ),
+            raises(TTLExpired),
+        )


### PR DESCRIPTION
All handlers now support `X-Request-TTL` field:
* If not set - sets it to a configurable number
* Always decrease the number
* If gets a message with `X-Request-TTL: 0` - raises

Why?
* Better logs
* Kill infinite handler loops

Details:
* Updates the TTL when receiving a message - not on sending
* Configuration - i'm not so sure about that - i've used `graph.config.sqs_message_context.initial_ttl` - even that we used it in the dispatcher
