### PR TITLE
X-Request-Ttl to opaque

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.11.0
+current_version = 1.11.1
 commit = False
 tag = False
 

--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -5,17 +5,45 @@ Message context.
 
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
+from microcosm_logging.decorators import logger
+
+from microcosm_pubsub.errors import TTLExpired
 
 
-def sqs_message_context(message_dct, **kwargs):
-    context = message_dct.get("opaque_data", dict())
+@logger
+class SQSMessageContext:
+    """
+    The message context controls what data you want to associate
+    with your daemon handler context, e.g. some combination of keys from the message or
+    additional metadata fetched from elsewhere.
 
-    # If there is a uri add it to the context
-    if message_dct.get("uri"):
-        context["uri"] = message_dct.get("uri")
+    """
+    def __init__(self, graph):
+        self.enable_ttl = graph.config.sqs_message_context.enable_ttl
+        self.initial_ttl = graph.config.sqs_message_context.initial_ttl
 
-    context.update(**kwargs)
-    return context
+    def __call__(self, message_dct, **kwargs):
+        context = message_dct.get("opaque_data", dict())
+
+        # If there is a uri add it to the context
+        if message_dct.get("uri"):
+            context["uri"] = message_dct.get("uri")
+
+        if self.enable_ttl:
+            try:
+                ttl = int(context["X-Request-Ttl"])
+            except KeyError:
+                ttl = self.initial_ttl
+            if ttl == 0:
+                self.logger.warning(
+                    "Error handling SQS message - TTL expired",
+                    extra=context,
+                )
+                raise TTLExpired(extra=context)
+            context["X-Request-Ttl"] = str(ttl - 1)
+
+        context.update(**kwargs)
+        return context
 
 
 @defaults(
@@ -24,12 +52,10 @@ def sqs_message_context(message_dct, **kwargs):
 )
 def configure_sqs_message_context(graph):
     """
-    Configure the message context function which controls what data you want to associate
-    with your daemon handler context, e.g. some combination of keys from the message or
-    additional metadata fetched from elsewhere.
+    Configure the message context object.
 
     Usage:
         graph.message_context()
 
     """
-    return sqs_message_context
+    return SQSMessageContext(graph)

--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -25,10 +25,18 @@ class SQSMessageContext:
     def __call__(self, message_dct, **kwargs):
         context = message_dct.get("opaque_data", dict())
 
+        self.update_context_uri(context, message_dct)
+        self.update_context_ttl(context)
+
+        context.update(**kwargs)
+        return context
+
+    def update_context_uri(self, context, message_dct):
         # If there is a uri add it to the context
         if message_dct.get("uri"):
             context["uri"] = message_dct.get("uri")
 
+    def update_context_ttl(self, context):
         if self.enable_ttl:
             try:
                 ttl = int(context["X-Request-Ttl"])
@@ -41,9 +49,6 @@ class SQSMessageContext:
                 )
                 raise TTLExpired(extra=context)
             context["X-Request-Ttl"] = str(ttl - 1)
-
-        context.update(**kwargs)
-        return context
 
 
 @defaults(

--- a/microcosm_pubsub/tests/test_context.py
+++ b/microcosm_pubsub/tests/test_context.py
@@ -4,8 +4,11 @@ Context tests.
 """
 from hamcrest import (
     assert_that,
+    calling,
     has_entries,
+    raises,
 )
+from microcosm_pubsub.errors import TTLExpired
 from microcosm_pubsub.tests.fixtures import ExampleDaemon
 
 
@@ -27,3 +30,33 @@ def test_handle():
             message_id=MESSAGE_ID,
             uri=MESSAGE_URI,
         )))
+
+
+def test_sets_ttl():
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+    message = {}
+
+    with graph.opaque.initialize(graph.sqs_message_context, message, message_id=MESSAGE_ID):
+        assert_that(graph.opaque.as_dict(), has_entries({
+            "X-Request-Ttl": "31",
+        }))
+
+
+def test_updates_ttl():
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+    message = {"opaque_data": {"X-Request-Ttl": "10"}}
+
+    with graph.opaque.initialize(graph.sqs_message_context, message, message_id=MESSAGE_ID):
+        assert_that(graph.opaque.as_dict(), has_entries({
+            "X-Request-Ttl": "9",
+        }))
+
+
+def test_zero_ttl():
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+    message = {"opaque_data": {"X-Request-Ttl": "0"}}
+
+    assert_that(calling(graph.sqs_message_context).with_args(message), raises(TTLExpired))

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -4,16 +4,13 @@ Dispatcher tests.
 """
 from hamcrest import (
     assert_that,
-    calling,
     equal_to,
     is_,
-    raises,
 )
 from mock import Mock
 
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.message import SQSMessage
-from microcosm_pubsub.errors import TTLExpired
 from microcosm_pubsub.tests.fixtures import (
     ExampleDaemon,
     DerivedSchema,
@@ -74,7 +71,9 @@ def test_handle_with_no_context():
     )
 
     assert_that(result, is_(equal_to(True)))
-    assert_that(graph.sqs_message_dispatcher.sqs_message_context(content), is_(equal_to(dict())))
+    assert_that(graph.sqs_message_dispatcher.sqs_message_context(content), is_(equal_to({
+        "X-Request-Ttl": "31",
+    })))
 
 
 def test_handle_with_skipping():
@@ -97,83 +96,3 @@ def test_handle_with_skipping():
         bound_handlers=daemon.bound_handlers,
     )
     assert_that(result, is_(equal_to(False)))
-
-
-def test_dispatcher_sets_ttl():
-    """
-    Test that the dispatcher handles a message and sets the context TTL if is not sets.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    content = dict()
-    sqs_message_context = Mock(return_value=dict())
-    with graph.opaque.initialize(sqs_message_context, content):
-        result = graph.sqs_message_dispatcher.handle_message(
-            message=SQSMessage(
-                consumer=None,
-                content=content,
-                media_type=DerivedSchema.MEDIA_TYPE,
-                message_id=MESSAGE_ID,
-                receipt_handle=None,
-            ),
-            bound_handlers=daemon.bound_handlers,
-        )
-
-    assert_that(result, is_(equal_to(True)))
-    sqs_message_context.assert_called_once_with(content)
-    assert_that(content, is_(equal_to({'X-Request-TTL': 31})))
-
-
-def test_dispatcher_updates_ttl():
-    """
-    Test that the dispatcher handles a message and updates the context TTL.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    content = {'X-Request-TTL': 10}
-    sqs_message_context = Mock(return_value=dict())
-    with graph.opaque.initialize(sqs_message_context, content):
-        result = graph.sqs_message_dispatcher.handle_message(
-            message=SQSMessage(
-                consumer=None,
-                content=content,
-                media_type=DerivedSchema.MEDIA_TYPE,
-                message_id=MESSAGE_ID,
-                receipt_handle=None,
-            ),
-            bound_handlers=daemon.bound_handlers,
-        )
-
-    assert_that(result, is_(equal_to(True)))
-    sqs_message_context.assert_called_once_with(content)
-    assert_that(content, is_(equal_to({'X-Request-TTL': 9})))
-
-
-def test_dispatcher_fails_for_zero_ttl():
-    """
-    Test that the dispatcher handles a message and updates the context TTL.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    content = {'X-Request-TTL': 0}
-    sqs_message_context = Mock(return_value=dict())
-    with graph.opaque.initialize(sqs_message_context, content):
-        assert_that(
-            calling(graph.sqs_message_dispatcher.handle_message).with_args(
-                message=SQSMessage(
-                    consumer=None,
-                    content=content,
-                    media_type=DerivedSchema.MEDIA_TYPE,
-                    message_id=MESSAGE_ID,
-                    receipt_handle=None,
-                ),
-                bound_handlers=daemon.bound_handlers,
-            ),
-            raises(TTLExpired),
-        )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "1.11.0"
+version = "1.11.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Few changes:
* Rename `X-Request-TTL` to `X-Request-Ttl` - to be compatible to other microcosm packages
*  Store `X-Request-Ttl` in graph.opaque instead of message context - standard convention
*  Pass `X-Request-Ttl` as a string (because the retrieved message contains strings)