### PR TITLE
Smart deferred-batch

### DIFF
--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -136,10 +136,13 @@ class DeferredBatchProducer(DeferredProducer):
             for media_type, message, topic_arn, opaque_data in self.messages
         ]
 
-        self.producer.produce(
-            MessageBatchSchema.MEDIA_TYPE,
-            messages=messages,
-        )
+        if len(messages) > 1:
+            self.producer.produce(
+                MessageBatchSchema.MEDIA_TYPE,
+                messages=messages,
+            )
+        elif len(messages) == 1:
+            self.producer.publish_message(**messages[0])
 
 
 def deferred(component, key="sns_producer"):


### PR DESCRIPTION
Optimization

Publish batch message only if we have to:
* If nothing was published - don't publish batch message
* If only one message was published - publish a regular message 