### PR TITLE
Use explicit naming for visibility timeout configuration

### DIFF
--- a/microcosm_pubsub/backoff.py
+++ b/microcosm_pubsub/backoff.py
@@ -12,8 +12,8 @@ MAX_BACKOFF_TIMEOUT = 60 * 60 * 12
 
 class BackoffPolicy(metaclass=ABCMeta):
 
-    def __init__(self, visibility_timeout_seconds=None):
-        self.visibility_timeout_seconds = visibility_timeout_seconds
+    def __init__(self, message_retry_visibility_timeout_seconds=None):
+        self.message_retry_visibility_timeout_seconds = message_retry_visibility_timeout_seconds
 
     @abstractmethod
     def compute_backoff_timeout(self, message, message_timeout):
@@ -35,7 +35,7 @@ class NaiveBackoffPolicy(BackoffPolicy):
 
     """
     def compute_backoff_timeout(self, message, message_timeout):
-        backoff_timeout = message_timeout or self.visibility_timeout_seconds
+        backoff_timeout = message_timeout or self.message_retry_visibility_timeout_seconds
         # we can only set integer timeouts
         return int(backoff_timeout) if backoff_timeout is not None else backoff_timeout
 
@@ -44,7 +44,7 @@ class ExponentialBackoffPolicy(BackoffPolicy):
     """
     Exponential backoff policy.
 
-    Uses a timeout scaled between 1 and an expontential limit.
+    Uses a timeout scaled between 1 and an exponential limit.
 
     """
     def compute_backoff_timeout(self, message, message_timeout):


### PR DESCRIPTION
This parameter was previously (internally) only used for configuring the
backoff-policy on retry, and only then if a timeout wasn't specified on
nack. The naming, however, did not make this clear, as it was ambiguous
as to which timeout scenario was being handled.

There are other existing handlers which do use the existing parameter name in other contexts; they will break, but in most shouldn't shouldn't need to use this configuration.