### PR TITLE
Initial refactor for pubsub dispatcher

### DIFF
--- a/microcosm_pubsub/backoff.py
+++ b/microcosm_pubsub/backoff.py
@@ -12,9 +12,6 @@ MAX_BACKOFF_TIMEOUT = 60 * 60 * 12
 
 class BackoffPolicy(metaclass=ABCMeta):
 
-    def __init__(self, message_retry_visibility_timeout_seconds=None):
-        self.message_retry_visibility_timeout_seconds = message_retry_visibility_timeout_seconds
-
     @abstractmethod
     def compute_backoff_timeout(self, message, message_timeout):
         pass
@@ -34,6 +31,9 @@ class NaiveBackoffPolicy(BackoffPolicy):
     Uses a fixed timeout from the message or system default.
 
     """
+    def __init__(self, message_retry_visibility_timeout_seconds, **kwargs):
+        self.message_retry_visibility_timeout_seconds = message_retry_visibility_timeout_seconds
+
     def compute_backoff_timeout(self, message, message_timeout):
         backoff_timeout = message_timeout or self.message_retry_visibility_timeout_seconds
         # we can only set integer timeouts
@@ -47,6 +47,9 @@ class ExponentialBackoffPolicy(BackoffPolicy):
     Uses a timeout scaled between 1 and an exponential limit.
 
     """
+    def __init__(self, **kwargs):
+        pass
+
     def compute_backoff_timeout(self, message, message_timeout):
         # exponential backoff means that on the Cth failure, timeout is maximized at N=2^C - 1
         upper = 2**message.approximate_receive_count - 1

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -77,13 +77,29 @@ class SQSConsumer:
         """
         Acknowledge that a message was NOT processed successfully.
 
-        Sets the visibility timeout if present
+        (Re)sets the retry visibility timeout on the message.
+
+        There are three cases here:
+         1.  We raised `Nack`; in this case, we explicitly wish to reprocess the message in the
+             near future; setting the visibility timeout is the right thing to do.
+
+         2a. We raised some non-`Nack` error and the `BackoffPolicy` HAS a configured value for its
+             `message_retry_visibility_timeout_seconds` meaning an operator has chosen to reprocess
+             all messages within that time limit; setting the visibility timeout is the right thing to do.
+
+         2b. We raised some non-`Nack` error and the `BackoffPolicy` DOES NOT HAVE a configured value for its
+             `message_retry_visibility_timeout_seconds` config meaning that the system will fallback to
+             its default behavior. We can either fallback to the SQS queue default (usually 30s) -- meaning
+             not setting the visibility timeout -- or we can enforce a default in this library -- using
+             the sqs consumer's config and override the SQS queue's visibility with a known, smallish value.
+
+             We choose the latter under the assumption that 30s is too long to reprocess most messages
+             as a defult and that long-running handlers will be configured accordingly (see: 2a).
+
+        Therefore: we always invoke `change_message_visibility`
 
         """
         timeout = self.backoff_policy.compute_backoff_timeout(message, visibility_timeout_seconds)
-        if timeout is None:
-            return
-
         self.sqs_client.change_message_visibility(
             QueueUrl=self.sqs_queue_url,
             ReceiptHandle=message.receipt_handle,
@@ -113,8 +129,8 @@ def configure_sqs_client(graph):
     limit=typed(int, default_value=10),
     # SQS will only return a few messages at time unless long polling is enabled (>0)
     wait_seconds=typed(int, default_value=1),
-    # By default, don't change message visibility when nacking with unspecified timeout
-    message_retry_visibility_timeout_seconds=typed(int, default_value=None)
+    # On error, change the visibility timeout when nacking
+    message_retry_visibility_timeout_seconds=typed(int, default_value=5)
 )
 def configure_sqs_consumer(graph):
     """
@@ -124,7 +140,7 @@ def configure_sqs_consumer(graph):
     sqs_queue_url = graph.config.sqs_consumer.sqs_queue_url
 
     if graph.metadata.testing or sqs_queue_url == "test":
-        from mock import MagicMock
+        from unittest.mock import MagicMock
         sqs_client = MagicMock()
     elif sqs_queue_url == STDIN:
         sqs_client = SQSStdInReader()

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -86,8 +86,8 @@ class ConsumerDaemon(Daemon):
         Implement daemon by sinking messages from the consumer to a dispatcher function.
 
         """
-        result = graph.sqs_message_dispatcher.handle_batch(self.bound_handlers)
-        if not result.message_count:
+        results = graph.sqs_message_dispatcher.handle_batch(self.bound_handlers)
+        if not results:
             raise SleepNow()
 
     @classmethod

--- a/microcosm_pubsub/message.py
+++ b/microcosm_pubsub/message.py
@@ -2,7 +2,6 @@
 A single SQS message.
 
 """
-from microcosm_pubsub.errors import Nack
 
 
 class SQSMessage:
@@ -39,14 +38,3 @@ class SQSMessage:
 
         """
         self.consumer.nack(self, visibility_timeout_seconds)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        if type is None:
-            self.ack()
-        elif isinstance(value, Nack):
-            self.nack(value.visibility_timeout_seconds)
-        else:
-            self.nack()

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -262,7 +262,7 @@ def configure_sns_producer(graph):
 
     """
     if graph.metadata.testing:
-        from mock import MagicMock
+        from unittest.mock import MagicMock
 
         if not graph.config.sns_producer.mock_sns:
             return MagicMock()

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -1,0 +1,57 @@
+"""
+Message handling result.
+
+"""
+from dataclasses import dataclass
+from enum import Enum, unique
+
+from microcosm_pubsub.errors import Nack, SkipMessage
+
+
+@unique
+class MessageHandlingResultType(Enum):
+    # Messaging handling failed.
+    FAILED = "FAILED"
+
+    # Messaging handling was intentionally retried.
+    RETRIED = "RETRIED"
+
+    # Message handling succeeded.
+    SUCCEEDED = "SUCCEEDED"
+
+    # Message handling was skipped.
+    # ("Upon closer inspection these are loafers")
+    SKIPPED = "SKIPPED"
+
+    def __str__(self):
+        return self.name
+
+
+@dataclass
+class MessageHandlingResult:
+    media_type: str
+    result: MessageHandlingResultType
+
+    @classmethod
+    def invoke(cls, func, message, **kwargs):
+        try:
+            success = func(message=message, **kwargs)
+            if success:
+                result = MessageHandlingResultType.SUCCEEDED
+            else:
+                result = MessageHandlingResultType.SKIPPED
+            message.ack()
+        except SkipMessage:
+            result = MessageHandlingResultType.SKIPPED
+            message.ack()
+        except Nack as nack:
+            result = MessageHandlingResultType.RETRIED
+            message.nack(nack.visibility_timeout_seconds)
+        except Exception as error:
+            result = MessageHandlingResultType.FAILED
+            message.nack()
+
+        return cls(
+            media_type=message.media_type,
+            result=result,
+        )

--- a/microcosm_pubsub/tests/test_backoff.py
+++ b/microcosm_pubsub/tests/test_backoff.py
@@ -3,7 +3,7 @@ Test backoff policies.
 
 """
 from hamcrest import assert_that, equal_to, is_
-from mock import patch
+from unittest.mock import patch
 
 from microcosm_pubsub.backoff import NaiveBackoffPolicy, ExponentialBackoffPolicy
 from microcosm_pubsub.message import SQSMessage

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -2,6 +2,8 @@
 Dispatcher tests.
 
 """
+from unittest.mock import Mock
+
 from hamcrest import (
     assert_that,
     calling,
@@ -9,7 +11,6 @@ from hamcrest import (
     is_,
     raises,
 )
-from mock import Mock
 
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.message import SQSMessage

--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -1,0 +1,143 @@
+"""
+Test result handling.
+
+"""
+from hamcrest import (
+    assert_that,
+    has_properties,
+)
+
+from microcosm_pubsub.errors import Nack, SkipMessage
+from microcosm_pubsub.message import SQSMessage
+from microcosm_pubsub.result import MessageHandlingResult, MessageHandlingResultType
+from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon
+
+
+MESSAGE_ID = "message-id"
+RECEIPT_HANDLE = "receipt-handle"
+
+
+class TestMessageHandlingResult:
+
+    def setup(self):
+        self.graph = ExampleDaemon.create_for_testing().graph
+        self.message = SQSMessage(
+            consumer=self.graph.sqs_consumer,
+            content=None,
+            media_type=DerivedSchema.MEDIA_TYPE,
+            message_id=MESSAGE_ID,
+            receipt_handle=RECEIPT_HANDLE,
+        )
+        self.graph.sqs_consumer.sqs_client.reset_mock()
+
+    def test_succeeded_truthy(self):
+        def func(message):
+            return True
+
+        result = MessageHandlingResult.invoke(
+            func=func,
+            message=self.message,
+        )
+
+        assert_that(
+            result,
+            has_properties(
+                media_type="application/vnd.microcosm.derived",
+                result=MessageHandlingResultType.SUCCEEDED,
+            ),
+        )
+        # ack
+        self.graph.sqs_consumer.sqs_client.delete_message.assert_called_with(
+            QueueUrl="queue",
+            ReceiptHandle=RECEIPT_HANDLE,
+        )
+
+    def test_skipped_falsey(self):
+        def func(message):
+            return False
+
+        result = MessageHandlingResult.invoke(
+            func=func,
+            message=self.message,
+        )
+
+        assert_that(
+            result,
+            has_properties(
+                media_type="application/vnd.microcosm.derived",
+                result=MessageHandlingResultType.SKIPPED,
+            ),
+        )
+        # ack
+        self.graph.sqs_consumer.sqs_client.delete_message.assert_called_with(
+            QueueUrl="queue",
+            ReceiptHandle=RECEIPT_HANDLE,
+        )
+
+    def test_skipped_exception(self):
+        def func(message):
+            raise SkipMessage("ignorance is bliss")
+
+        result = MessageHandlingResult.invoke(
+            func=func,
+            message=self.message,
+        )
+
+        assert_that(
+            result,
+            has_properties(
+                media_type="application/vnd.microcosm.derived",
+                result=MessageHandlingResultType.SKIPPED,
+            ),
+        )
+        # ack
+        self.graph.sqs_consumer.sqs_client.delete_message.assert_called_with(
+            QueueUrl="queue",
+            ReceiptHandle=RECEIPT_HANDLE,
+        )
+
+    def test_retried_nack(self):
+        def func(message):
+            raise Nack(3)
+
+        result = MessageHandlingResult.invoke(
+            func=func,
+            message=self.message,
+        )
+
+        assert_that(
+            result,
+            has_properties(
+                media_type="application/vnd.microcosm.derived",
+                result=MessageHandlingResultType.RETRIED,
+            ),
+        )
+        # nack with custom retry visibility timeout
+        self.graph.sqs_consumer.sqs_client.change_message_visibility.assert_called_with(
+            QueueUrl="queue",
+            ReceiptHandle=RECEIPT_HANDLE,
+            VisibilityTimeout=3,
+        )
+
+    def test_failed_exception(self):
+        def func(message):
+            raise Exception("FAIL")
+
+        result = MessageHandlingResult.invoke(
+            func=func,
+            message=self.message,
+        )
+
+        assert_that(
+            result,
+            has_properties(
+                media_type="application/vnd.microcosm.derived",
+                result=MessageHandlingResultType.FAILED,
+            ),
+        )
+        # nack with default retry visibility timeout
+        self.graph.sqs_consumer.sqs_client.change_message_visibility.assert_called_with(
+            QueueUrl="queue",
+            ReceiptHandle=RECEIPT_HANDLE,
+            VisibilityTimeout=5,
+        )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     },
     tests_require=[
         "coverage>=3.7.1",
-        "mock>=1.0.1",
         "PyHamcrest>=1.8.5",
     ],
 )


### PR DESCRIPTION
The inner layers of the pubsub dispatcher combine flow control, context management, logging,
timing, and n(ack) results confusingly. This is a first pass at cleaning up this logic,
with an eye towards better measurement of behavior.

Also: embrace `unittest.mock`