### PR TITLE
Use separate variable to control nack timeouts in URIHandlers

### DIFF
--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -32,10 +32,15 @@ class URIHandler:
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, graph, nack_timeout=1, resource_nack_timeout=1):
+    def __init__(self, graph, retry_nack_timeout=1, resource_nack_timeout=1):
         self.sqs_message_context = graph.sqs_message_context
-        self.nack_timeout = nack_timeout
+        self.retry_nack_timeout = retry_nack_timeout
         self.resource_nack_timeout = resource_nack_timeout
+
+    @property
+    def nack_timeout(self):
+        """Deprecated, use retry_nack_timeout"""
+        return self.retry_nack_timeout
 
     @property
     def name(self):

--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -32,9 +32,10 @@ class URIHandler:
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, graph, nack_timeout=1):
+    def __init__(self, graph, nack_timeout=1, resource_nack_timeout=1):
         self.sqs_message_context = graph.sqs_message_context
         self.nack_timeout = nack_timeout
+        self.resource_nack_timeout = resource_nack_timeout
 
     @property
     def name(self):
@@ -122,7 +123,7 @@ class URIHandler:
         headers = self.sqs_message_context(message)
         response = get(uri, headers=headers)
         if response.status_code == codes.not_found and self.nack_if_not_found:
-            raise Nack(self.nack_timeout)
+            raise Nack(self.resource_nack_timeout)
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION
There are cases where handlers downstream will explicitly nack events
using `nack_timeout`, and will override the default value. This should
be a separate concern from the default nack we configure to control how
we handle 404s on resource retrieve.