### PR TITLE
Keep Nack

### DIFF
--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -114,7 +114,7 @@ class SQSMessageDispatcher:
                 ),
                 extra=self.sqs_message_context(content)
             )
-            raise TTLExpired()
+            raise
         except Exception as error:
             logger.warning(
                 "Error handling SQS message: {}".format(


### PR DESCRIPTION
We were losing the `Nack` error because of (hopefully) a code change added for local testing.