### PR TITLE
Improve clarity of SQSMessageContext

### DIFF
--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -10,57 +10,60 @@ from microcosm_logging.decorators import logger
 from microcosm_pubsub.errors import TTLExpired
 
 
-@logger
-class SQSMessageContext:
-    """
-    The message context controls what data you want to associate
-    with your daemon handler context, e.g. some combination of keys from the message or
-    additional metadata fetched from elsewhere.
-
-    """
-    def __init__(self, graph):
-        self.enable_ttl = graph.config.sqs_message_context.enable_ttl
-        self.initial_ttl = graph.config.sqs_message_context.initial_ttl
-
-    def __call__(self, message_dct, **kwargs):
-        context = message_dct.get("opaque_data", dict())
-
-        self.update_context_uri(context, message_dct)
-        self.update_context_ttl(context)
-
-        context.update(**kwargs)
-        return context
-
-    def update_context_uri(self, context, message_dct):
-        # If there is a uri add it to the context
-        if message_dct.get("uri"):
-            context["uri"] = message_dct.get("uri")
-
-    def update_context_ttl(self, context):
-        if self.enable_ttl:
-            try:
-                ttl = int(context["X-Request-Ttl"])
-            except KeyError:
-                ttl = self.initial_ttl
-            if ttl == 0:
-                self.logger.warning(
-                    "Error handling SQS message - TTL expired",
-                    extra=context,
-                )
-                raise TTLExpired(extra=context)
-            context["X-Request-Ttl"] = str(ttl - 1)
+TTL_KEY = "X-Request-Ttl"
 
 
 @defaults(
     enable_ttl=typed(boolean, default_value=True),
     initial_ttl=typed(int, default_value=32),
 )
-def configure_sqs_message_context(graph):
+@logger
+class SQSMessageContext:
     """
-    Configure the message context object.
-
-    Usage:
-        graph.message_context()
+    Factory for per-message contexts.
 
     """
-    return SQSMessageContext(graph)
+    def __init__(self, graph):
+        self.enable_ttl = graph.config.sqs_message_context.enable_ttl
+        self.initial_ttl = graph.config.sqs_message_context.initial_ttl
+
+    def __call__(self, message, **kwargs):
+        """
+        Create a new context from a message.
+
+        """
+        # start with opaque data passed in message
+        if "opaque_data" in message:
+            context = message["opaque_data"].copy()
+        else:
+            context = dict()
+
+        # merge in explicit and derived arguments
+        context.update(
+            **self.uri_for(context, message),
+            **self.ttl_for(context, message),
+            **kwargs,
+        )
+
+        return context
+
+    def uri_for(self, context, message):
+        uri = message.get("uri")
+        return dict(uri=uri) if uri else dict()
+
+    def ttl_for(self, context, message):
+        try:
+            ttl = int(context[TTL_KEY])
+        except KeyError:
+            ttl = self.initial_ttl
+
+        if ttl == 0:
+            self.logger.warning(
+                "Error handling SQS message - TTL expired",
+                extra=context,
+            )
+            raise TTLExpired(extra=context)
+
+        return {
+            TTL_KEY: str(ttl - 1),
+        }

--- a/microcosm_pubsub/tests/test_context.py
+++ b/microcosm_pubsub/tests/test_context.py
@@ -16,47 +16,51 @@ MESSAGE_ID = "message_id"
 MESSAGE_URI = "message_uri"
 
 
-def test_handle():
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
+class TestSQSMessageContext:
 
-    message = dict(
-        opaque_data=dict(foo="bar"),
-        uri=MESSAGE_URI,
-    )
-    with graph.opaque.initialize(graph.sqs_message_context, message, message_id=MESSAGE_ID):
-        assert_that(graph.opaque.as_dict(), has_entries(dict(
-            foo="bar",
-            message_id=MESSAGE_ID,
+    def setup(self):
+        self.graph = ExampleDaemon.create_for_testing().graph
+
+    def test_handle(self):
+        message = dict(
+            opaque_data=dict(foo="bar"),
             uri=MESSAGE_URI,
-        )))
+        )
 
+        with self.graph.opaque.initialize(self.graph.sqs_message_context, message, message_id=MESSAGE_ID):
+            assert_that(
+                self.graph.opaque.as_dict(),
+                has_entries(
+                    foo="bar",
+                    message_id=MESSAGE_ID,
+                    uri=MESSAGE_URI,
+                ),
+            )
 
-def test_sets_ttl():
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-    message = {}
+    def test_sets_ttl(self):
+        with self.graph.opaque.initialize(self.graph.sqs_message_context, {}, message_id=MESSAGE_ID):
+            assert_that(
+                self.graph.opaque.as_dict(),
+                has_entries({
+                    "X-Request-Ttl": "31",
+                }),
+            )
 
-    with graph.opaque.initialize(graph.sqs_message_context, message, message_id=MESSAGE_ID):
-        assert_that(graph.opaque.as_dict(), has_entries({
-            "X-Request-Ttl": "31",
-        }))
+    def test_updates_ttl(self):
+        message = {"opaque_data": {"X-Request-Ttl": "10"}}
 
+        with self.graph.opaque.initialize(self.graph.sqs_message_context, message, message_id=MESSAGE_ID):
+            assert_that(
+                self.graph.opaque.as_dict(),
+                has_entries({
+                    "X-Request-Ttl": "9",
+                }),
+            )
 
-def test_updates_ttl():
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-    message = {"opaque_data": {"X-Request-Ttl": "10"}}
+    def test_zero_ttl(self):
+        message = {"opaque_data": {"X-Request-Ttl": "0"}}
 
-    with graph.opaque.initialize(graph.sqs_message_context, message, message_id=MESSAGE_ID):
-        assert_that(graph.opaque.as_dict(), has_entries({
-            "X-Request-Ttl": "9",
-        }))
-
-
-def test_zero_ttl():
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-    message = {"opaque_data": {"X-Request-Ttl": "0"}}
-
-    assert_that(calling(graph.sqs_message_context).with_args(message), raises(TTLExpired))
+        assert_that(
+            calling(self.graph.sqs_message_context).with_args(message),
+            raises(TTLExpired),
+        )

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -6,15 +6,12 @@ from unittest.mock import Mock
 
 from hamcrest import (
     assert_that,
-    calling,
     equal_to,
     is_,
-    raises,
 )
 
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.message import SQSMessage
-from microcosm_pubsub.errors import TTLExpired
 from microcosm_pubsub.tests.fixtures import (
     ExampleDaemon,
     DerivedSchema,
@@ -100,83 +97,3 @@ def test_handle_with_skipping():
         bound_handlers=daemon.bound_handlers,
     )
     assert_that(result, is_(equal_to(False)))
-
-
-def test_dispatcher_sets_ttl():
-    """
-    Test that the dispatcher handles a message and sets the context TTL if is not sets.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    content = dict()
-    sqs_message_context = Mock(return_value=dict())
-    with graph.opaque.initialize(sqs_message_context, content):
-        result = graph.sqs_message_dispatcher.handle_message(
-            message=SQSMessage(
-                consumer=None,
-                content=content,
-                media_type=DerivedSchema.MEDIA_TYPE,
-                message_id=MESSAGE_ID,
-                receipt_handle=None,
-            ),
-            bound_handlers=daemon.bound_handlers,
-        )
-
-    assert_that(result, is_(equal_to(True)))
-    sqs_message_context.assert_called_once_with(content)
-    assert_that(content, is_(equal_to({'X-Request-TTL': 31})))
-
-
-def test_dispatcher_updates_ttl():
-    """
-    Test that the dispatcher handles a message and updates the context TTL.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    content = {'X-Request-TTL': 10}
-    sqs_message_context = Mock(return_value=dict())
-    with graph.opaque.initialize(sqs_message_context, content):
-        result = graph.sqs_message_dispatcher.handle_message(
-            message=SQSMessage(
-                consumer=None,
-                content=content,
-                media_type=DerivedSchema.MEDIA_TYPE,
-                message_id=MESSAGE_ID,
-                receipt_handle=None,
-            ),
-            bound_handlers=daemon.bound_handlers,
-        )
-
-    assert_that(result, is_(equal_to(True)))
-    sqs_message_context.assert_called_once_with(content)
-    assert_that(content, is_(equal_to({'X-Request-TTL': 9})))
-
-
-def test_dispatcher_fails_for_zero_ttl():
-    """
-    Test that the dispatcher handles a message and updates the context TTL.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    content = {'X-Request-TTL': 0}
-    sqs_message_context = Mock(return_value=dict())
-    with graph.opaque.initialize(sqs_message_context, content):
-        assert_that(
-            calling(graph.sqs_message_dispatcher.handle_message).with_args(
-                message=SQSMessage(
-                    consumer=None,
-                    content=content,
-                    media_type=DerivedSchema.MEDIA_TYPE,
-                    message_id=MESSAGE_ID,
-                    receipt_handle=None,
-                ),
-                bound_handlers=daemon.bound_handlers,
-            ),
-            raises(TTLExpired),
-        )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "microcosm.factories": [
             "pubsub_message_schema_registry = microcosm_pubsub.registry:configure_schema_registry",
             "pubsub_lifecycle_change = microcosm_pubsub.conventions:LifecycleChange",
-            "sqs_message_context = microcosm_pubsub.context:configure_sqs_message_context",
+            "sqs_message_context = microcosm_pubsub.context:SQSMessageContext",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",
             "sqs_envelope = microcosm_pubsub.envelope:configure_sqs_envelope",
             "sqs_message_dispatcher = microcosm_pubsub.dispatcher:configure",


### PR DESCRIPTION
The opaque/context abstraction is still hard to follow and the pubsub usage herein
has some unclear assumptions, but we can simplify a little without much pain