### PR TITLE
Simplify usage of opaque context in message dispatcher

### DIFF
--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -27,31 +27,31 @@ class SQSMessageContext:
         self.enable_ttl = graph.config.sqs_message_context.enable_ttl
         self.initial_ttl = graph.config.sqs_message_context.initial_ttl
 
-    def __call__(self, message, **kwargs):
+    def __call__(self, content, **kwargs):
         """
-        Create a new context from a message.
+        Create a new context from message content.
 
         """
         # start with opaque data passed in message
-        if "opaque_data" in message:
-            context = message["opaque_data"].copy()
+        if "opaque_data" in content:
+            context = content["opaque_data"].copy()
         else:
             context = dict()
 
         # merge in explicit and derived arguments
         context.update(
-            **self.uri_for(context, message),
-            **self.ttl_for(context, message),
+            **self.uri_for(context, content),
+            **self.ttl_for(context, content),
             **kwargs,
         )
 
         return context
 
-    def uri_for(self, context, message):
-        uri = message.get("uri")
+    def uri_for(self, context, content):
+        uri = content.get("uri")
         return dict(uri=uri) if uri else dict()
 
-    def ttl_for(self, context, message):
+    def ttl_for(self, context, content):
         try:
             ttl = int(context[TTL_KEY])
         except KeyError:

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -35,11 +35,12 @@ class MessageHandlingResultType(Enum):
 
 @dataclass
 class MessageHandlingResult:
+    elapsed_time: float
     media_type: str
     result: MessageHandlingResultType
 
     @classmethod
-    def invoke(cls, func, message, **kwargs):
+    def invoke(cls, func, message, opaque=None, **kwargs):
         try:
             success = func(message=message, **kwargs)
             if success:
@@ -64,6 +65,8 @@ class MessageHandlingResult:
             message.nack()
 
         return cls(
+            # XXX will not yet work because `invoke` is called outside of timing loop
+            elapsed_time=opaque.as_dict().get("elapsed_time") if opaque else None,
             media_type=message.media_type,
             result=result,
         )

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -2,19 +2,21 @@
 Dispatcher tests.
 
 """
-from unittest.mock import Mock
-
 from hamcrest import (
     assert_that,
     calling,
-    equal_to,
-    is_,
+    contains,
+    greater_than,
+    has_entries,
+    has_properties,
     raises,
 )
 
+from microcosm_pubsub.context import TTL_KEY
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.errors import IgnoreMessage
 from microcosm_pubsub.message import SQSMessage
+from microcosm_pubsub.result import MessageHandlingResultType
 from microcosm_pubsub.tests.fixtures import (
     ExampleDaemon,
     DerivedSchema,
@@ -24,81 +26,80 @@ from microcosm_pubsub.tests.fixtures import (
 MESSAGE_ID = "message-id"
 
 
-def test_handle():
-    """
-    Test that the dispatcher handles a message and assigns context.
+class TestDispatcher:
 
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
+    def setup(self):
+        self.daemon = ExampleDaemon.create_for_testing()
+        self.graph = self.daemon.graph
 
-    content = dict(bar="baz")
-    sqs_message_context = Mock(return_value=dict())
-    with graph.opaque.initialize(sqs_message_context, content):
-        result = graph.sqs_message_dispatcher.handle_message(
-            message=SQSMessage(
-                consumer=None,
-                content=content,
-                media_type=DerivedSchema.MEDIA_TYPE,
-                message_id=MESSAGE_ID,
-                receipt_handle=None,
-            ),
-            bound_handlers=daemon.bound_handlers,
-        )
+        self.dispatcher = self.graph.sqs_message_dispatcher
 
-    assert_that(result, is_(equal_to(True)))
-    sqs_message_context.assert_called_once_with(content)
-
-
-def test_handle_with_no_context():
-    """
-    Test that when no context is added the dispatcher behaves sanely.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    # remove the sqs_message_context from the graph so we can test the dispatcher
-    # defaulting logic
-    graph._registry.entry_points.pop("sqs_message_context")
-
-    content = dict(bar="baz")
-    result = graph.sqs_message_dispatcher.handle_message(
-        message=SQSMessage(
-            consumer=None,
-            content=content,
+        self.content = dict(bar="baz", uri="http://example.com")
+        self.message = SQSMessage(
+            consumer=self.graph.sqs_consumer,
+            content=self.content,
             media_type=DerivedSchema.MEDIA_TYPE,
             message_id=MESSAGE_ID,
             receipt_handle=None,
-        ),
-        bound_handlers=daemon.bound_handlers,
-    )
+        )
+        self.graph.sqs_consumer.sqs_client.reset_mock()
 
-    assert_that(result, is_(equal_to(True)))
-    assert_that(graph.sqs_message_dispatcher.sqs_message_context(content), is_(equal_to({
-        "X-Request-Ttl": "31",
-    })))
-
-
-def test_handle_unsupported_media_type():
-    """
-    Unsupported media types are ignored.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    content = dict(bar="baz")
-    assert_that(
-        calling(graph.sqs_message_dispatcher.handle_message).with_args(
-            message=SQSMessage(
-                consumer=None,
-                content=content,
-                media_type=created("bar"),
-                message_id=MESSAGE_ID,
-                receipt_handle=None,
+    def test_handle_or_ignore_message_handles_message(self):
+        result = self.dispatcher.handle_or_ignore_message(
+            message=self.message,
+            bound_handlers=self.daemon.bound_handlers,
+        )
+        assert_that(
+            result,
+            has_properties(
+                result=MessageHandlingResultType.SUCCEEDED,
             ),
-            bound_handlers=daemon.bound_handlers,
-        ),
-        raises(IgnoreMessage),
-    )
+        )
+
+    def test_handle_or_ignore_message_ignores_unsupported_media_type(self):
+        """
+        Unsupported media types are ignored.
+
+        """
+        assert_that(
+            calling(self.dispatcher.handle_or_ignore_message).with_args(
+                message=SQSMessage(
+                    consumer=None,
+                    content=self.content,
+                    media_type=created("bar"),
+                    message_id=MESSAGE_ID,
+                    receipt_handle=None,
+                ),
+                bound_handlers=self.daemon.bound_handlers,
+            ),
+            raises(IgnoreMessage),
+        )
+
+    def test_handle_message_succeeded(self):
+        result = self.dispatcher.handle_message(
+            message=self.message,
+            content=self.content,
+            handler=self.graph.noop_handler,
+        )
+        assert_that(
+            result,
+            contains(
+                True,
+                greater_than(0.0),
+            ),
+        )
+
+    def test_message_context_default_values(self):
+        with self.dispatcher.message_context(
+            message=self.message,
+            content=self.content,
+            handler=self.graph.noop_handler,
+        ) as extra:
+            assert_that(
+                extra,
+                has_entries({
+                    "uri": "http://example.com",
+                    TTL_KEY: "31",
+                    "message_id": MESSAGE_ID,
+                }),
+            )


### PR DESCRIPTION
The opaque context is meant to capture generic state during program execution and
propagate to downstream services (via swagger or SNS calls). The dispatcher uses
this context in numerous ways and has let these usages get out-of-control:

 1. The dispatcher initializes a new context once it has enough information to
    not `IGNORE` a message

 2. The dispatcher records timing data within this context.

 3. The dispatcher explicitly passes `extra` to its logger using this context.

 4. The dispatcher overwrites handler loggers to use this context as their `extra`

This PR brings together the first three cases (but no yet the fourth) and lays
groundwork for recording timing data.