### PR TITLE
Simplify usage of opaque context in message dispatcher

### DIFF
--- a/microcosm_pubsub/constants.py
+++ b/microcosm_pubsub/constants.py
@@ -1,0 +1,7 @@
+"""
+Constants.
+
+"""
+
+TTL_KEY = "X-Request-Ttl"
+URI_KEY = "uri"

--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -2,15 +2,14 @@
 Message context.
 
 """
+from typing import Dict
 
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
 from microcosm_logging.decorators import logger
 
-from microcosm_pubsub.errors import TTLExpired
-
-
-TTL_KEY = "X-Request-Ttl"
+from microcosm_pubsub.constants import TTL_KEY, URI_KEY
+from microcosm_pubsub.message import SQSMessage
 
 
 @defaults(
@@ -27,43 +26,39 @@ class SQSMessageContext:
         self.enable_ttl = graph.config.sqs_message_context.enable_ttl
         self.initial_ttl = graph.config.sqs_message_context.initial_ttl
 
-    def __call__(self, message, **kwargs):
+    def __call__(self, context, **kwargs) -> Dict[str, str]:
         """
         Create a new context from a message.
 
         """
-        # start with opaque data passed in message
-        if "opaque_data" in message:
-            context = message["opaque_data"].copy()
-        else:
-            context = dict()
+        if isinstance(context, SQSMessage):
+            return self.from_sqs_message(context, **kwargs)
 
-        # merge in explicit and derived arguments
-        context.update(
-            **self.uri_for(context, message),
-            **self.ttl_for(context, message),
+        # XXX we want to remove this
+        return self.from_dict(context, **kwargs)
+
+    def from_sqs_message(self, message, **kwargs):
+        context = dict(
+            # include the message id
+            message_id=message.message_id,
+            # include
+            **message.opaque_data,
             **kwargs,
         )
 
+        # include the TTL (if enabled)
+        if self.enable_ttl:
+            ttl = message.ttl if message.ttl is not None else self.initial_ttl
+            context[TTL_KEY] = str(ttl - 1)
+
+        # include the URI (if there is one)
+        if message.uri:
+            context[URI_KEY] = message.uri
+
         return context
 
-    def uri_for(self, context, message):
-        uri = message.get("uri")
-        return dict(uri=uri) if uri else dict()
-
-    def ttl_for(self, context, message):
-        try:
-            ttl = int(context[TTL_KEY])
-        except KeyError:
-            ttl = self.initial_ttl
-
-        if ttl == 0:
-            self.logger.warning(
-                "Error handling SQS message - TTL expired",
-                extra=context,
-            )
-            raise TTLExpired(extra=context)
-
-        return {
-            TTL_KEY: str(ttl - 1),
-        }
+    def from_dict(self, dct, **kwargs):
+        return dict(
+            **dct.get("opaque_data", {}),
+            **kwargs,
+        )

--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -125,7 +125,8 @@ class URIHandler:
         Passes message context.
 
         """
-        headers = self.sqs_message_context(message)
+        # XXX we only want X-Request headers
+        headers = self.opaque.as_dict()
         response = get(uri, headers=headers)
         if response.status_code == codes.not_found and self.nack_if_not_found:
             raise Nack(self.resource_nack_timeout)

--- a/microcosm_pubsub/message.py
+++ b/microcosm_pubsub/message.py
@@ -2,6 +2,7 @@
 A single SQS message.
 
 """
+from microcosm_pubsub.constants import TTL_KEY
 
 
 class SQSMessage:
@@ -38,3 +39,21 @@ class SQSMessage:
 
         """
         self.consumer.nack(self, visibility_timeout_seconds)
+
+    @property
+    def opaque_data(self):
+        if not self.content:
+            return dict()
+        return self.content.get("opaque_data", {})
+
+    @property
+    def ttl(self):
+        if TTL_KEY not in self.opaque_data:
+            return None
+        return int(self.opaque_data[TTL_KEY])
+
+    @property
+    def uri(self):
+        if not self.content:
+            return None
+        return self.content.get("uri")

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -37,6 +37,7 @@ class MessageHandlingResultType(Enum):
 class MessageHandlingResult:
     media_type: str
     result: MessageHandlingResultType
+    elapsed_time: float = None
 
     @classmethod
     def invoke(cls, func, message, **kwargs):

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -2,19 +2,15 @@
 Dispatcher tests.
 
 """
-from unittest.mock import Mock
-
 from hamcrest import (
     assert_that,
-    calling,
-    equal_to,
-    is_,
-    raises,
+    greater_than,
+    has_properties,
 )
 
 from microcosm_pubsub.conventions import created
-from microcosm_pubsub.errors import IgnoreMessage
 from microcosm_pubsub.message import SQSMessage
+from microcosm_pubsub.result import MessageHandlingResultType
 from microcosm_pubsub.tests.fixtures import (
     ExampleDaemon,
     DerivedSchema,
@@ -24,81 +20,71 @@ from microcosm_pubsub.tests.fixtures import (
 MESSAGE_ID = "message-id"
 
 
-def test_handle():
-    """
-    Test that the dispatcher handles a message and assigns context.
+class TestDispatcher:
 
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
+    def setup(self):
+        self.daemon = ExampleDaemon.create_for_testing()
+        self.graph = self.daemon.graph
 
-    content = dict(bar="baz")
-    sqs_message_context = Mock(return_value=dict())
-    with graph.opaque.initialize(sqs_message_context, content):
-        result = graph.sqs_message_dispatcher.handle_message(
-            message=SQSMessage(
-                consumer=None,
-                content=content,
-                media_type=DerivedSchema.MEDIA_TYPE,
-                message_id=MESSAGE_ID,
-                receipt_handle=None,
-            ),
-            bound_handlers=daemon.bound_handlers,
-        )
+        self.dispatcher = self.graph.sqs_message_dispatcher
 
-    assert_that(result, is_(equal_to(True)))
-    sqs_message_context.assert_called_once_with(content)
-
-
-def test_handle_with_no_context():
-    """
-    Test that when no context is added the dispatcher behaves sanely.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    # remove the sqs_message_context from the graph so we can test the dispatcher
-    # defaulting logic
-    graph._registry.entry_points.pop("sqs_message_context")
-
-    content = dict(bar="baz")
-    result = graph.sqs_message_dispatcher.handle_message(
-        message=SQSMessage(
-            consumer=None,
-            content=content,
+        self.content = dict(bar="baz", uri="http://example.com")
+        self.message = SQSMessage(
+            consumer=self.graph.sqs_consumer,
+            content=self.content,
             media_type=DerivedSchema.MEDIA_TYPE,
             message_id=MESSAGE_ID,
             receipt_handle=None,
-        ),
-        bound_handlers=daemon.bound_handlers,
-    )
+        )
+        self.graph.sqs_consumer.sqs_client.reset_mock()
 
-    assert_that(result, is_(equal_to(True)))
-    assert_that(graph.sqs_message_dispatcher.sqs_message_context(content), is_(equal_to({
-        "X-Request-Ttl": "31",
-    })))
-
-
-def test_handle_unsupported_media_type():
-    """
-    Unsupported media types are ignored.
-
-    """
-    daemon = ExampleDaemon.create_for_testing()
-    graph = daemon.graph
-
-    content = dict(bar="baz")
-    assert_that(
-        calling(graph.sqs_message_dispatcher.handle_message).with_args(
-            message=SQSMessage(
-                consumer=None,
-                content=content,
-                media_type=created("bar"),
-                message_id=MESSAGE_ID,
-                receipt_handle=None,
+    def test_handle_message_succeeded(self):
+        result = self.dispatcher.handle_message(
+            message=self.message,
+            bound_handlers=self.daemon.bound_handlers,
+        )
+        assert_that(
+            result,
+            has_properties(
+                elapsed_time=greater_than(0.0),
+                result=MessageHandlingResultType.SUCCEEDED,
             ),
-            bound_handlers=daemon.bound_handlers,
-        ),
-        raises(IgnoreMessage),
-    )
+        )
+
+    def test_handle_message_ignored(self):
+        """
+        Unsupported media types are ignored.
+
+        """
+        self.message.media_type = created("bar")
+        assert_that(
+            self.dispatcher.handle_message(
+                message=self.message,
+                bound_handlers=self.daemon.bound_handlers,
+            ),
+            has_properties(
+                elapsed_time=greater_than(0.0),
+                result=MessageHandlingResultType.IGNORED,
+            ),
+        )
+
+    def test_handle_message_expired(self):
+        """
+        Unsupported media types are ignored.
+
+        """
+        self.message.content = dict(
+            opaque_data={
+                "X-Request-Ttl": "0",
+            },
+        )
+        assert_that(
+            self.dispatcher.handle_message(
+                message=self.message,
+                bound_handlers=self.daemon.bound_handlers,
+            ),
+            has_properties(
+                elapsed_time=greater_than(0.0),
+                result=MessageHandlingResultType.EXPIRED,
+            ),
+        )


### PR DESCRIPTION
The opaque context is meant to capture generic state during program execution and
propagate to downstream services (via swagger or SNS calls). The dispatcher uses
this context in numerous ways and has let these usages get out-of-control:

 1. The dispatcher initializes a new context once it has enough information to
    not `IGNORE` a message

 2. The dispatcher records timing data within this context.

 3. The dispatcher explicitly passes `extra` to its logger using this context.

 4. The dispatcher overwrites handler loggers to use this context as their `extra`

This PR brings together the first three cases (but no yet the fourth) and lays
groundwork for recording timing data.