### PR TITLE
Use opaque for URI handler headers.

### DIFF
--- a/microcosm_pubsub/tests/handlers/test_uri_handler.py
+++ b/microcosm_pubsub/tests/handlers/test_uri_handler.py
@@ -1,6 +1,7 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from hamcrest import assert_that, equal_to, instance_of, is_
+from microcosm.api import create_object_graph
 
 from microcosm_pubsub.handlers import URIHandler
 
@@ -81,4 +82,56 @@ class TestURIHandler:
         assert_that(
             resource.foo,
             is_(equal_to("bar")),
+        )
+
+    def test_get_resource_empty_headers(self):
+        graph = create_object_graph("microcosm")
+        graph.use(
+            "opaque",
+            "sqs_message_context",
+        )
+        graph.lock()
+
+        uri = "http://localhost"
+        message = dict(
+            uri=uri,
+        )
+
+        with patch("microcosm_pubsub.handlers.uri_handler.get") as mocked_get:
+            handler = URIHandler(graph)
+            handler.get_resource(message, uri)
+
+        mocked_get.assert_called_with(
+            uri,
+            headers=dict(),
+        )
+
+    def test_get_resource_forward_headers(self):
+        graph = create_object_graph("microcosm")
+        graph.use(
+            "opaque",
+            "sqs_message_context",
+        )
+        graph.lock()
+
+        uri = "http://localhost"
+        message = dict(
+            uri=uri,
+        )
+
+        def func():
+            return {
+                "X-Request-Id": "request-id",
+            }
+
+        with patch("microcosm_pubsub.handlers.uri_handler.get") as mocked_get:
+            handler = URIHandler(graph)
+            with graph.opaque.initialize(func):
+                handler.get_resource(message, uri)
+
+        mocked_get.assert_called_with(
+            uri,
+            headers={
+                "X-Request-Id": "request-id",
+            },
         )


### PR DESCRIPTION
This is consistent with other (internal) usage for swagger clients.