### PR TITLE
GLOB-26005: demonic metrics

### DIFF
--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -24,6 +24,7 @@ class SQSMessageDispatcher:
         self.sqs_consumer = graph.sqs_consumer
         self.sqs_message_context = graph.sqs_message_context
         self.sqs_message_handler_registry = graph.sqs_message_handler_registry
+        self.send_metrics = graph.pubsub_send_metrics
 
     def handle_batch(self, bound_handlers) -> List[MessageHandlingResult]:
         """
@@ -62,6 +63,7 @@ class SQSMessageDispatcher:
                 logger=self.choose_logger(handler),
                 opaque=self.opaque,
             )
+            self.send_metrics(instance)
             return instance
 
     def validate_ttl(self):

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -31,10 +31,13 @@ class SQSMessageDispatcher:
         Send a batch of messages to a function.
 
         """
-        return [
+        instances = [
             self.handle_message(message, bound_handlers)
             for message in self.sqs_consumer.consume()
         ]
+        for instance in instances:
+            self.send_metrics(instance)
+        return instances
 
     def handle_message(self, message, bound_handlers) -> MessageHandlingResult:
         """
@@ -63,7 +66,6 @@ class SQSMessageDispatcher:
                 logger=self.choose_logger(handler),
                 opaque=self.opaque,
             )
-            self.send_metrics(instance)
             return instance
 
     def validate_ttl(self):

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -5,21 +5,21 @@ from microcosm.config.types import boolean
 from microcosm_pubsub.result import MessageHandlingResultType
 
 
-def do_nothing(results):
+def do_nothing(dummy, result):
     return
 
 
-def send_metrics(metrics, results):
-    if results.result == MessageHandlingResultType.IGNORED:
+def send_metrics(metrics, result):
+    if result.result == MessageHandlingResultType.IGNORED:
         return
     tags = [
         "source:micrcocosm-pubsub",
-        f"result:{results.result}",
-        f"media-type:{results.media_type}",
+        f"result:{result.result}",
+        f"media-type:{result.media_type}",
     ]
     metrics.histogram(
         "message",
-        results.elapsed_time,
+        result.elapsed_time,
         tags=tags,
     )
 
@@ -30,6 +30,6 @@ def send_metrics(metrics, results):
 def configure_pubsub_metrics(graph):
     enable_metrics = graph.config.pubsub_send_metrics.enable
     if not enable_metrics:
-        return do_nothing
+        return partial(do_nothing, None)
     else:
         return partial(send_metrics, graph.metrics)

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,6 +1,7 @@
 from distutils.util import strtobool
 
-from microcosm.api import defaults
+from microcosm.api import defaults, typed
+from microcosm.config.types import boolean
 from microcosm_pubsub.result import MessageHandlingResultType
 
 
@@ -9,10 +10,10 @@ def do_nothing(results):
 
 
 @defaults(
-    enable="false",
+    enable=typed(boolean, default_value=False)
 )
 def configure_pubsub_metrics(graph):
-    enable_metrics = strtobool(graph.config.pubsub_send_metrics.enable)
+    enable_metrics = graph.config.pubsub_send_metrics.enable
     if not enable_metrics:
         return do_nothing
     graph.use("metrics")

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,0 +1,36 @@
+from distutils.util import strtobool
+
+from microcosm.api import defaults
+from microcosm_pubsub.result import MessageHandlingResultType
+
+def do_nothing(results):
+    return
+
+@defaults(
+    enable_metrics="false",
+)
+def configure_pubsub_metrics(graph):
+    enable_metrics = strtobool(graph.config.route.enable_metrics)
+    if not enable_metrics:
+        return do_nothing
+    metrics = graph.metrics
+    tags = ["source:micrcocosm-pubsub"]
+    
+    def send_metrics(results):
+        if results.result == MessageHandlingResultType.IGNORED:
+            return
+        extra_tags = [
+            f"result:{results.result}",
+            f"media-type:{results.media_type}",
+        ]
+        graph.metrics.increment(
+            "message_count",
+            tags=tags + extra_tags,
+        )
+        graph.metrics.histogram(
+            "message",
+            results.elapsed_time,
+            tags=tags + extra_tags,
+        )
+
+    return send_metrics

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
 from microcosm_pubsub.result import MessageHandlingResultType
@@ -7,6 +9,21 @@ def do_nothing(results):
     return
 
 
+def send_metrics(metrics, results):
+    if results.result == MessageHandlingResultType.IGNORED:
+        return
+    tags = [
+        "source:micrcocosm-pubsub",
+        f"result:{results.result}",
+        f"media-type:{results.media_type}",
+    ]
+    metrics.histogram(
+        "message",
+        results.elapsed_time,
+        tags=tags,
+    )
+
+
 @defaults(
     enable=typed(boolean, default_value=False)
 )
@@ -14,20 +31,5 @@ def configure_pubsub_metrics(graph):
     enable_metrics = graph.config.pubsub_send_metrics.enable
     if not enable_metrics:
         return do_nothing
-    graph.use("metrics")
-    tags = ["source:micrcocosm-pubsub"]
-
-    def send_metrics(results):
-        if results.result == MessageHandlingResultType.IGNORED:
-            return
-        extra_tags = [
-            f"result:{results.result}",
-            f"media-type:{results.media_type}",
-        ]
-        graph.metrics.histogram(
-            "message",
-            results.elapsed_time,
-            tags=tags + extra_tags,
-        )
-
-    return send_metrics
+    else:
+        return partial(send_metrics, graph.metrics)

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,5 +1,3 @@
-from distutils.util import strtobool
-
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
 from microcosm_pubsub.result import MessageHandlingResultType

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -9,10 +9,10 @@ def do_nothing(results):
 
 
 @defaults(
-    enable_metrics="false",
+    enable="false",
 )
 def configure_pubsub_metrics(graph):
-    enable_metrics = strtobool(graph.config.pubsub_send_metrics.enable_metrics)
+    enable_metrics = strtobool(graph.config.pubsub_send_metrics.enable)
     if not enable_metrics:
         return do_nothing
     graph.use("metrics")
@@ -25,10 +25,6 @@ def configure_pubsub_metrics(graph):
             f"result:{results.result}",
             f"media-type:{results.media_type}",
         ]
-        graph.metrics.increment(
-            "message_count",
-            tags=tags + extra_tags,
-        )
         graph.metrics.histogram(
             "message",
             results.elapsed_time,

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -3,8 +3,10 @@ from distutils.util import strtobool
 from microcosm.api import defaults
 from microcosm_pubsub.result import MessageHandlingResultType
 
+
 def do_nothing(results):
     return
+
 
 @defaults(
     enable_metrics="false",
@@ -13,9 +15,9 @@ def configure_pubsub_metrics(graph):
     enable_metrics = strtobool(graph.config.pubsub_send_metrics.enable_metrics)
     if not enable_metrics:
         return do_nothing
-    metrics = graph.metrics
+    graph.use("metrics")
     tags = ["source:micrcocosm-pubsub"]
-    
+
     def send_metrics(results):
         if results.result == MessageHandlingResultType.IGNORED:
             return

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -10,7 +10,7 @@ def do_nothing(results):
     enable_metrics="false",
 )
 def configure_pubsub_metrics(graph):
-    enable_metrics = strtobool(graph.config.route.enable_metrics)
+    enable_metrics = strtobool(graph.config.pubsub_send_metrics.enable_metrics)
     if not enable_metrics:
         return do_nothing
     metrics = graph.metrics

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -93,15 +93,15 @@ class TestDispatcher:
     def test_handle_batch_with_message_succeeded(self):
         batch = [
             dict(
-                    MessageId=MESSAGE_ID,
-                    ReceiptHandle="receipt-handle",
-                    Body=dumps(dict(
-                        Message=dumps(dict(
-                            mediaType=DerivedSchema.MEDIA_TYPE,
-                            bar="baz",
-                            uri="http://example.com",
-                        )),
-                    )))
+                MessageId=MESSAGE_ID,
+                ReceiptHandle="receipt-handle",
+                Body=dumps(dict(
+                    Message=dumps(dict(
+                        mediaType=DerivedSchema.MEDIA_TYPE,
+                        bar="baz",
+                        uri="http://example.com",
+                    )),
+                )))
         ]
         self.dispatcher.sqs_consumer.sqs_client.receive_message.value = dict(Messages=batch)
         result = self.dispatcher.handle_batch(

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
         "microcosm-daemon>=1.0.0",
         "microcosm-logging>=1.0.0",
     ],
+    extras_require={
+        "metrics": "microcosm-metrics>=2.0.0",
+    },
     setup_requires=[
         "nose>=1.3.6",
     ],

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "microcosm.factories": [
             "pubsub_message_schema_registry = microcosm_pubsub.registry:configure_schema_registry",
             "pubsub_lifecycle_change = microcosm_pubsub.conventions:LifecycleChange",
+            "pubsub_send_metrics = microcosm_pubsub.metrics:configure_pubsub_metrics",
             "sqs_message_context = microcosm_pubsub.context:SQSMessageContext",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",
             "sqs_envelope = microcosm_pubsub.envelope:configure_sqs_envelope",


### PR DESCRIPTION
## Why?

We want to have visibility into the behavior of `pubsub` daemons. This has the daemons send latencies (appropriately tagged) to a `statsd` daemon using `microcosm-metrics`. Note that we make sure to include the `result` and the `media-type` as tags, enabling us to cut and slice these things at the aggregator.

## Example StatsD output

This shows how the data looks when using the Prometheus's project `statsd_exporter`.
If using Prometheus to collect the metrics,
this correlates to how things will look when using Prometheus queries.

```
# HELP message Metric autogenerated by statsd_exporter.
# TYPE message summary
message{environment="undefined",media_type="application/vnd.microcosm.derived",result="EXPIRED",service="example",source="micrcocosm-pubsub",quantile="0.5"} 2.4080276489257812e-05
message{environment="undefined",media_type="application/vnd.microcosm.derived",result="EXPIRED",service="example",source="micrcocosm-pubsub",quantile="0.9"} 2.4080276489257812e-05
message{environment="undefined",media_type="application/vnd.microcosm.derived",result="EXPIRED",service="example",source="micrcocosm-pubsub",quantile="0.99"} 2.4080276489257812e-05
message_sum{environment="undefined",media_type="application/vnd.microcosm.derived",result="EXPIRED",service="example",source="micrcocosm-pubsub"} 2.4080276489257812e-05
message_count{environment="undefined",media_type="application/vnd.microcosm.derived",result="EXPIRED",service="example",source="micrcocosm-pubsub"} 1
message{environment="undefined",media_type="application/vnd.microcosm.derived",result="SUCCEEDED",service="example",source="micrcocosm-pubsub",quantile="0.5"} 0.001641988754272461
message{environment="undefined",media_type="application/vnd.microcosm.derived",result="SUCCEEDED",service="example",source="micrcocosm-pubsub",quantile="0.9"} 0.001641988754272461
message{environment="undefined",media_type="application/vnd.microcosm.derived",result="SUCCEEDED",service="example",source="micrcocosm-pubsub",quantile="0.99"} 0.001641988754272461
message_sum{environment="undefined",media_type="application/vnd.microcosm.derived",result="SUCCEEDED",service="example",source="micrcocosm-pubsub"} 0.001641988754272461
message_count{environment="undefined",media_type="application/vnd.microcosm.derived",result="SUCCEEDED",service="example",source="micrcocosm-pubsub"} 1
```