### PR TITLE
Fix case where opaque_data contains message ID

### DIFF
--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -34,7 +34,7 @@ class SQSMessageContext:
         return self.from_sqs_message(context, **kwargs)
 
     def from_sqs_message(self, message: SQSMessage, **kwargs):
-        context: Dict = message.opaque_data
+        context: Dict = dict(message.opaque_data)
 
         context.update(
             # include the message id

--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -33,12 +33,12 @@ class SQSMessageContext:
         """
         return self.from_sqs_message(context, **kwargs)
 
-    def from_sqs_message(self, message, **kwargs):
-        context = dict(
+    def from_sqs_message(self, message: SQSMessage, **kwargs):
+        context: Dict = message.opaque_data
+
+        context.update(
             # include the message id
             message_id=message.message_id,
-            # include
-            **message.opaque_data,
             **kwargs,
         )
 

--- a/microcosm_pubsub/tests/test_context.py
+++ b/microcosm_pubsub/tests/test_context.py
@@ -78,3 +78,26 @@ class TestSQSMessageContext:
                     "X-Request-Ttl": "9",
                 }),
             )
+
+    def test_handle_existing_opaque_message_id(self):
+        self.message = SQSMessage(
+            consumer=self.graph.sqs_consumer,
+            content=dict(
+                opaque_data=dict(
+                    foo="bar",
+                    message_id="opaque_message_id",
+                ),
+                uri=MESSAGE_URI,
+            ),
+            media_type=None,
+            message_id=MESSAGE_ID,
+            receipt_handle=None,
+        )
+
+        with self.graph.opaque.initialize(self.graph.sqs_message_context, self.message):
+            assert_that(
+                self.graph.opaque.as_dict(),
+                has_entries(
+                    message_id=MESSAGE_ID,
+                ),
+            )


### PR DESCRIPTION
When we publish messages, we tend to publish them with the entirety of
the opaque data, which itself includes the previous message ID of the
message processed by another producer.

This reverts back to the original, previous behavior where we start with
the opaque_data, and override values as they're specified by
message_id/kwargs.

Note that there may be other cases of repeated kwargs. This only takes
message_id into account for now.