### PR TITLE
Add ability to skip a message seen too many times

### DIFF
--- a/microcosm_pubsub/backoff.py
+++ b/microcosm_pubsub/backoff.py
@@ -5,8 +5,6 @@ Consumer backoff policy
 from abc import ABCMeta, abstractmethod
 from random import randint
 
-from microcosm_pubsub.errors import SkipMessage
-
 
 # we cannot go over 12 hours
 MAX_BACKOFF_TIMEOUT = 60 * 60 * 12
@@ -33,14 +31,10 @@ class NaiveBackoffPolicy(BackoffPolicy):
     Uses a fixed timeout from the message or system default.
 
     """
-    def __init__(self, message_retry_visibility_timeout_seconds, message_max_processing_attempts, **kwargs):
+    def __init__(self, message_retry_visibility_timeout_seconds, **kwargs):
         self.message_retry_visibility_timeout_seconds = message_retry_visibility_timeout_seconds
-        self.max_processing_attempts = message_max_processing_attempts
 
     def compute_backoff_timeout(self, message, message_timeout):
-        if self.max_processing_attempts > 0 and message.approximate_receive_count > self.max_processing_attempts:
-            return -1
-
         backoff_timeout = message_timeout or self.message_retry_visibility_timeout_seconds
         # we can only set integer timeouts
         return int(backoff_timeout) if backoff_timeout is not None else backoff_timeout

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 
 from boto3 import Session
 from microcosm.api import defaults, typed
+from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.backoff import BackoffPolicy
 from microcosm_pubsub.reader import SQSFileReader, SQSStdInReader
@@ -22,6 +23,7 @@ def is_file(url):
     return exists(urlparse(url).path)
 
 
+@logger
 class SQSConsumer:
     """
     Consume message from a (single) SQS queue.
@@ -100,11 +102,22 @@ class SQSConsumer:
 
         """
         timeout = self.backoff_policy.compute_backoff_timeout(message, visibility_timeout_seconds)
+        if timeout < 0:
+            return self.skip_nack(message)
         self.sqs_client.change_message_visibility(
             QueueUrl=self.sqs_queue_url,
             ReceiptHandle=message.receipt_handle,
             VisibilityTimeout=timeout,
         )
+
+    def skip_nack(self, message):
+        self.logger.info(
+            "Message has exceeded the maximum of {attempts} processing attempts. Skipping",
+            extra=dict(
+                attempts=self.backoff_policy.max_processing_attempts,
+            )
+        )
+        self.ack(message)
 
 
 def configure_sqs_client(graph):
@@ -130,7 +143,10 @@ def configure_sqs_client(graph):
     # SQS will only return a few messages at time unless long polling is enabled (>0)
     wait_seconds=typed(int, default_value=1),
     # On error, change the visibility timeout when nacking
-    message_retry_visibility_timeout_seconds=typed(int, default_value=5)
+    message_retry_visibility_timeout_seconds=typed(int, default_value=5),
+    # Number of failed attempts after which the message stops being processed
+    # Only used by the CutoffBackoffPolicy; only meant to be used in non-SQS contexts
+    message_max_processing_attempts=typed(int, default_value=-1)
 )
 def configure_sqs_consumer(graph):
     """
@@ -155,6 +171,7 @@ def configure_sqs_consumer(graph):
 
     backoff_policy = backoff_policy_class(
         message_retry_visibility_timeout_seconds=graph.config.sqs_consumer.message_retry_visibility_timeout_seconds,
+        message_max_processing_attempts=graph.config.sqs_consumer.message_max_processing_attempts,
     )
 
     return SQSConsumer(

--- a/microcosm_pubsub/tests/test_backoff.py
+++ b/microcosm_pubsub/tests/test_backoff.py
@@ -2,10 +2,11 @@
 Test backoff policies.
 
 """
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import assert_that, calling, equal_to, is_, raises
 from unittest.mock import patch
 
-from microcosm_pubsub.backoff import NaiveBackoffPolicy, ExponentialBackoffPolicy
+from microcosm_pubsub.backoff import ExponentialBackoffPolicy, NaiveBackoffPolicy
+from microcosm_pubsub.errors import SkipMessage
 from microcosm_pubsub.message import SQSMessage
 
 
@@ -14,7 +15,7 @@ def test_default_timeout():
         None, None, None, None, None,
         approximate_receive_count=1,
     )
-    backoff_policy = NaiveBackoffPolicy(42)
+    backoff_policy = NaiveBackoffPolicy(42, -1)
 
     assert_that(
         backoff_policy.compute_backoff_timeout(message, None),
@@ -27,13 +28,35 @@ def test_message_timeout():
         None, None, None, None, None,
         approximate_receive_count=1,
     )
-    backoff_policy = NaiveBackoffPolicy(42)
+    backoff_policy = NaiveBackoffPolicy(42, -1)
 
     assert_that(
         backoff_policy.compute_backoff_timeout(message, 77),
         is_(equal_to(77)),
     )
 
+def test_skip_past_max_attempts():
+    backoff_policy = NaiveBackoffPolicy(33, 5)
+
+    message = SQSMessage(
+        None, None, None, None, None,
+        approximate_receive_count=4,
+    )
+
+    assert_that(
+        backoff_policy.compute_backoff_timeout(message, None),
+        is_(equal_to(33)),
+    )
+
+    message = SQSMessage(
+        None, None, None, None, None,
+        approximate_receive_count=6,
+    )
+
+    assert_that(
+        calling(backoff_policy.compute_backoff_timeout).with_args(message, None),
+        raises(SkipMessage),
+    )
 
 def test_exponential_timeout():
     message = SQSMessage(

--- a/microcosm_pubsub/tests/test_backoff.py
+++ b/microcosm_pubsub/tests/test_backoff.py
@@ -2,11 +2,10 @@
 Test backoff policies.
 
 """
-from hamcrest import assert_that, calling, equal_to, is_, raises
+from hamcrest import assert_that, equal_to, is_
 from unittest.mock import patch
 
 from microcosm_pubsub.backoff import ExponentialBackoffPolicy, NaiveBackoffPolicy
-from microcosm_pubsub.errors import SkipMessage
 from microcosm_pubsub.message import SQSMessage
 
 
@@ -15,7 +14,7 @@ def test_default_timeout():
         None, None, None, None, None,
         approximate_receive_count=1,
     )
-    backoff_policy = NaiveBackoffPolicy(42, -1)
+    backoff_policy = NaiveBackoffPolicy(42)
 
     assert_that(
         backoff_policy.compute_backoff_timeout(message, None),
@@ -28,35 +27,13 @@ def test_message_timeout():
         None, None, None, None, None,
         approximate_receive_count=1,
     )
-    backoff_policy = NaiveBackoffPolicy(42, -1)
+    backoff_policy = NaiveBackoffPolicy(42)
 
     assert_that(
         backoff_policy.compute_backoff_timeout(message, 77),
         is_(equal_to(77)),
     )
 
-def test_skip_past_max_attempts():
-    backoff_policy = NaiveBackoffPolicy(33, 5)
-
-    message = SQSMessage(
-        None, None, None, None, None,
-        approximate_receive_count=4,
-    )
-
-    assert_that(
-        backoff_policy.compute_backoff_timeout(message, None),
-        is_(equal_to(33)),
-    )
-
-    message = SQSMessage(
-        None, None, None, None, None,
-        approximate_receive_count=6,
-    )
-
-    assert_that(
-        calling(backoff_policy.compute_backoff_timeout).with_args(message, None),
-        raises(SkipMessage),
-    )
 
 def test_exponential_timeout():
     message = SQSMessage(


### PR DESCRIPTION
LocalStack doesn't have deadlettering capabilities. To avoid processing the same failing message again and again, we make it possible to just skip it after a certain number of attempts.
- Change default backoff policy to return negative timeout after too many attempts
- Default config to max of `-1` attempts, interpreted as turning off the limit in number of attempts.