### PR TITLE
Release: Slice deferred message batches

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.16.0
+current_version = 1.17.0
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-pubsub"
-version = "1.16.0"
+version = "1.17.0"
 
 setup(
     name=project,


### PR DESCRIPTION
AWS appears to have some limitations regarding message sizes, such that we
run into errors when trying to exceed those limits (for example, a message
containing a payload of 8MB was rejected).

This adds an extra configuration and behavior to split incoming batched
messages into smaller batches before being publishing.