### PR TITLE
Add matcher for published messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.mypy_cache

--- a/microcosm_pubsub/chain/context_decorators.py
+++ b/microcosm_pubsub/chain/context_decorators.py
@@ -1,5 +1,5 @@
 from functools import wraps, WRAPPER_ASSIGNMENTS
-from inspect import signature, _POSITIONAL_ONLY, _POSITIONAL_OR_KEYWORD, _empty
+from inspect import Parameter, signature, Signature
 
 from microcosm_pubsub.chain.decorators import EXTRACTS, BINDS
 
@@ -19,7 +19,7 @@ def get_positional_args(func):
         (arg, parameter.default)
         for arg, parameter
         in signature(func).parameters.items()
-        if parameter.kind in (_POSITIONAL_ONLY, _POSITIONAL_OR_KEYWORD)
+        if parameter.kind in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
     ]
 
 
@@ -34,7 +34,7 @@ def get_from_context(context, func, assigned=DEFAULT_ASSIGNED):
     @wraps(func, assigned=assigned + WRAPPER_ASSIGNMENTS)
     def decorate(*args, **kwargs):
         context_kwargs = {
-            arg_name: (context[arg_name] if default is _empty else context.get(arg_name, default))
+            arg_name: (context[arg_name] if default is Signature.empty else context.get(arg_name, default))
             for arg_name, default in positional_args[len(args):]
             if arg_name not in kwargs
         }

--- a/microcosm_pubsub/envelope.py
+++ b/microcosm_pubsub/envelope.py
@@ -120,7 +120,7 @@ class SQSEnvelope(MessageBodyParser, MediaTypeAndContentParser):
 
     """
     def __init__(self, graph):
-        self.validate_md5 = graph.config.sqs_envelope.validate_md5
+        self.should_validate_md5 = graph.config.sqs_envelope.validate_md5
 
     def parse_raw_message(self, consumer, raw_message):
         """
@@ -134,7 +134,7 @@ class SQSEnvelope(MessageBodyParser, MediaTypeAndContentParser):
 
         body = self.parse_body(raw_message)
 
-        if self.validate_md5:
+        if self.should_validate_md5:
             self.validate_md5(raw_message, body)
 
         message = self.parse_message(body)

--- a/microcosm_pubsub/matchers/__init__.py
+++ b/microcosm_pubsub/matchers/__init__.py
@@ -1,0 +1,34 @@
+"""
+Hamcrest-style matchers for PubSub messages.
+
+Note that this package depends on `PyHamcrest`, which is intentionally not an
+installation dependency of `microcosm-pubsub` (but is a test dependnency).
+
+Users are expected to install `PyHamcrest` as a test dependency and import
+this package as part of their unit tests (and not their runtime).
+
+"""
+from microcosm_pubsub.matchers.message import (
+    has_media_type,
+    has_uri,
+    PublishedMessage,
+    PublishedMessageMatcher,
+)
+from microcosm_pubsub.matchers.publishing import (
+    published,
+    published_inanyorder,
+    published_messages_for,
+    published_nothing,
+)
+
+
+__all__ = [  # type: ignore
+    has_media_type,
+    has_uri,
+    published,
+    published_inanyorder,
+    published_messages_for,
+    published_nothing,
+    PublishedMessage,
+    PublishedMessageMatcher,
+]

--- a/microcosm_pubsub/matchers/message.py
+++ b/microcosm_pubsub/matchers/message.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+from json import loads
+from typing import Iterable, Optional, Mapping
+
+from hamcrest import not_none
+from hamcrest.core.helpers.wrap_matcher import wrap_matcher
+from hamcrest.library.object.hasproperty import IsObjectWithProperty
+
+
+@dataclass
+class PublishedMessage:
+    """
+    A published message.
+
+    """
+    topic_arn: str
+    message: Mapping[str, str]
+
+    @property
+    def media_type(self) -> Optional[str]:
+        return self.message.get("mediaType")
+
+    @property
+    def uri(self) -> Optional[str]:
+        return self.message.get("uri")
+
+    @classmethod
+    def from_call(cls, call) -> "PublishedMessage":
+        name, args, kwargs = call
+
+        # NB: we could use the envelope functions to parse the inner message
+        topic_arn = kwargs["TopicArn"]
+        message = loads(kwargs["Message"])
+        return cls(
+            topic_arn=topic_arn,
+            message=message,
+        )
+
+    @staticmethod
+    def iter_from_mock_calls(mock_calls) -> Iterable["PublishedMessage"]:
+        """
+        Iterate over published messages among mock calls.
+
+        """
+        return [
+            PublishedMessage.from_call(mock_call)
+            for mock_call in mock_calls
+            # NB: _Call is a tuple of (name, args, kwargs)
+            if "TopicArn" in mock_call[-1] and "Message" in mock_call[-1]
+        ]
+
+    @staticmethod
+    def iter_from_sns_producer(sns_producer) -> Iterable["PublishedMessage"]:
+        """
+        Iterate over published messages from a mocked SNSProducer.
+
+        """
+        return PublishedMessage.iter_from_mock_calls(sns_producer.sns_client.publish.mock_calls)
+
+
+class PublishedMessageMatcher(IsObjectWithProperty):
+    """
+    A matcher that validates a single published message property.
+
+    This matcher is primarily a cosmetric change describe errors in terms of messages
+    (and not generic objects).
+
+    """
+    def describe_to(self, description):
+        return description.append_text(
+            f"a message with a {self.property_name} matching ",
+        ).append_description_of(
+            self.value_matcher,
+        )
+
+
+def has_media_type(match=None):
+    # NB: if no matcher is provider, just check that *some* media type exists
+    if match is None:
+        match = not_none()
+
+    return PublishedMessageMatcher("media_type", wrap_matcher(match))
+
+
+def has_uri(match=None):
+    # NB: if no matcher is provider, just check that *some* uri exists
+    if match is None:
+        match = not_none()
+
+    return PublishedMessageMatcher("uri", wrap_matcher(match))

--- a/microcosm_pubsub/matchers/publishing.py
+++ b/microcosm_pubsub/matchers/publishing.py
@@ -1,0 +1,57 @@
+"""
+Matchers for message publishing.
+
+"""
+from typing import List
+
+from hamcrest.core.helpers.wrap_matcher import wrap_matcher
+from hamcrest.library.collection.issequence_containinginorder import IsSequenceContainingInOrder
+from hamcrest.library.collection.issequence_containinginanyorder import IsSequenceContainingInAnyOrder
+
+from microcosm_pubsub.matchers.message import PublishedMessage
+
+
+def published_messages_for(sns_producer) -> List[PublishedMessage]:
+    return list(PublishedMessage.iter_from_sns_producer(sns_producer))
+
+
+class NonStrictPublishingMatcher(IsSequenceContainingInAnyOrder):
+    """
+    Matcher that validates a sequence of published messages extracted from an SNSProducer.
+
+    """
+    def matches(self, sns_producer, mismatch_description=None):
+        return super().matches(
+            published_messages_for(sns_producer),
+            mismatch_description,
+        )
+
+
+class StrictPublishingMatcher(IsSequenceContainingInOrder):
+    """
+    Matcher that validates a sequence of published messages extracted from an SNSProducer.
+
+    """
+    def matches(self, sns_producer, mismatch_description=None):
+        return super().matches(
+            published_messages_for(sns_producer),
+            mismatch_description,
+        )
+
+
+def published(*matchers, strict=True):
+    return StrictPublishingMatcher([
+        wrap_matcher(matcher)
+        for matcher in matchers
+    ])
+
+
+def published_inanyorder(*matchers, strict=True):
+    return NonStrictPublishingMatcher([
+        wrap_matcher(matcher)
+        for matcher in matchers
+    ])
+
+
+def published_nothing(*matchers):
+    return StrictPublishingMatcher([])

--- a/microcosm_pubsub/tests/test_matcher.py
+++ b/microcosm_pubsub/tests/test_matcher.py
@@ -1,0 +1,79 @@
+"""
+Test customized matcher.
+
+"""
+from hamcrest import assert_that, all_of
+from microcosm.api import create_object_graph, load_from_dict
+
+from microcosm_pubsub.conventions import created
+from microcosm_pubsub.matchers import (
+    has_media_type,
+    has_uri,
+    published,
+    published_inanyorder,
+    published_nothing,
+)
+
+
+class TestPublishingMatcher:
+
+    def setup(self):
+        loader = load_from_dict(
+            sns_topic_arns=dict(
+                default="topic",
+            )
+        )
+        self.graph = create_object_graph("example", testing=True, loader=loader)
+        self.graph.sns_producer.sns_client.reset_mocks()
+
+    def test_publish_no_messages(self):
+        assert_that(
+            self.graph.sns_producer,
+            published_nothing(),
+        )
+
+    def test_publish_one_message(self):
+        self.graph.sns_producer.produce(created("foo"), data="data")
+
+        assert_that(
+            self.graph.sns_producer,
+            published(
+                has_media_type(created("foo")),
+            ),
+        )
+
+    def test_publish_two_messages(self):
+        self.graph.sns_producer.produce(created("foo"), uri="http://localhost")
+        self.graph.sns_producer.produce(created("bar"), uri="http://localhost")
+
+        assert_that(
+            self.graph.sns_producer,
+            published(
+                all_of(
+                    has_media_type(created("foo")),
+                    has_uri(),
+                ),
+                all_of(
+                    has_media_type(created("bar")),
+                    has_uri("http://localhost"),
+                ),
+            ),
+        )
+
+    def test_publish_two_messages_non_strict(self):
+        self.graph.sns_producer.produce(created("foo"), uri="http://localhost")
+        self.graph.sns_producer.produce(created("bar"), uri="http://localhost")
+
+        assert_that(
+            self.graph.sns_producer,
+            published_inanyorder(
+                all_of(
+                    has_media_type(created("bar")),
+                    has_uri("http://localhost"),
+                ),
+                all_of(
+                    has_media_type(created("foo")),
+                    has_uri(),
+                ),
+            ),
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [flake8]
 max-line-length = 120
 max-complexity = 15
+
+[mypy]
+ignore_missing_imports = True


### PR DESCRIPTION
Extend and wrap base `hamcrest` matchers for `contains` and `hasproperty` to work
with mocked SNS producer calls.