### PR TITLE
Create a more reasonable default for SNS metrics

### DIFF
--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,35 +1,52 @@
-from functools import partial
-
 from microcosm.api import defaults, typed
+from microcosm.errors import NotBoundError
 from microcosm.config.types import boolean
 from microcosm_pubsub.result import MessageHandlingResultType
 
 
-def do_nothing(dummy, result):
-    return
-
-
-def send_metrics(metrics, result):
-    if result.result == MessageHandlingResultType.IGNORED:
-        return
-    tags = [
-        "source:micrcocosm-pubsub",
-        f"result:{result.result}",
-        f"media-type:{result.media_type}",
-    ]
-    metrics.histogram(
-        "message",
-        result.elapsed_time,
-        tags=tags,
-    )
-
-
 @defaults(
-    enable=typed(boolean, default_value=False)
+    enabled=typed(boolean, default_value=True)
 )
-def configure_pubsub_metrics(graph):
-    enable_metrics = graph.config.pubsub_send_metrics.enable
-    if not enable_metrics:
-        return partial(do_nothing, None)
-    else:
-        return partial(send_metrics, graph.metrics)
+class PubSubSendMetrics:
+
+    def __init__(self, graph):
+        self.metrics = self.get_metrics(graph)
+        self.enabled = bool(
+            self.metrics
+            and self.metrics.host != "localhost"
+            and graph.config.pubsub_send_metrics.enabled
+        )
+
+    def get_metrics(self, graph):
+        """
+        Fetch the metrics client from the graph.
+
+        Metrics will be disabled if the not configured.
+
+        """
+        try:
+            return graph.metrics
+        except NotBoundError:
+            return None
+
+    def __call__(self, result):
+        """
+        Send metrics if enabled.
+
+        """
+        if not self.enabled:
+            return
+
+        if result.result == MessageHandlingResultType.IGNORED:
+            return
+
+        tags = [
+            "source:micrcocosm-pubsub",
+            f"result:{result.result}",
+            f"media-type:{result.media_type}",
+        ]
+        self.metrics.histogram(
+            "message",
+            result.elapsed_time,
+            tags=tags,
+        )

--- a/microcosm_pubsub/tests/test_metrics.py
+++ b/microcosm_pubsub/tests/test_metrics.py
@@ -1,0 +1,60 @@
+"""
+Test metrics enablement.
+
+"""
+from unittest.mock import Mock, patch
+
+from hamcrest import assert_that, equal_to, is_
+from microcosm.api import create_object_graph, load_from_dict
+
+from microcosm_pubsub.metrics import PubSubSendMetrics
+
+
+def test_configure_metrics_default_metrics_not_installed():
+    """
+    Disable metrics by default if metrics not installed.
+
+    """
+    with patch.object(PubSubSendMetrics, "get_metrics") as mocked:
+        mocked.return_value = None
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_metrics_default_metrics_installed():
+    """
+    Enabled metrics by default if installed.
+
+    """
+    with patch.object(PubSubSendMetrics, "get_metrics") as mocked:
+        mocked.return_value = Mock(host="localhost")
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_metrics_default_metrics_configured():
+    """
+    Enabled metrics by default if installed.
+
+    """
+    with patch.object(PubSubSendMetrics, "get_metrics") as mocked:
+        mocked.return_value = Mock(host="statsd")
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_metrics.enabled, is_(equal_to(True)))
+
+
+def test_configure_metrics_disable():
+    """
+    Disable metrics explicitly.
+
+    """
+    loader = load_from_dict(
+        pubsub_send_metrics=dict(
+            enabled=False,
+        ),
+    )
+    graph = create_object_graph("example", testing=True, loader=loader)
+    assert_that(graph.pubsub_send_metrics.enabled, is_(equal_to(False)))

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ setup(
         "marshmallow>=2.15.0",
         "microcosm>=2.0.0",
         "microcosm-daemon>=1.0.0",
-        "microcosm-logging>=1.0.0",
+        "microcosm-logging>=1.3.0",
     ],
     extras_require={
-        "metrics": "microcosm-metrics>=2.0.0",
+        "metrics": "microcosm-metrics>=2.2.0",
     },
     setup_requires=[
         "nose>=1.3.6",
@@ -39,7 +39,7 @@ setup(
         "microcosm.factories": [
             "pubsub_message_schema_registry = microcosm_pubsub.registry:configure_schema_registry",
             "pubsub_lifecycle_change = microcosm_pubsub.conventions:LifecycleChange",
-            "pubsub_send_metrics = microcosm_pubsub.metrics:configure_pubsub_metrics",
+            "pubsub_send_metrics = microcosm_pubsub.metrics:PubSubSendMetrics",
             "sqs_message_context = microcosm_pubsub.context:SQSMessageContext",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",
             "sqs_envelope = microcosm_pubsub.envelope:configure_sqs_envelope",


### PR DESCRIPTION
 - Enable if installed and configured (by default)
 - Disable if not installed, not configured, or not defaulted

Enables removal of repetitive configuration.