### PR TITLE
Make switch statement rely on __eq__

### DIFF
--- a/microcosm_pubsub/chain/statements/case.py
+++ b/microcosm_pubsub/chain/statements/case.py
@@ -11,5 +11,5 @@ class CaseStatement:
         self.key = key
 
     def then(self, *args, **kwargs):
-        self.switch._cases[self.key] = Chain.make(*args, **kwargs)
+        self.switch._add_action_for_key(self.key, Chain.make(*args, **kwargs))
         return self.switch

--- a/microcosm_pubsub/chain/statements/switch.py
+++ b/microcosm_pubsub/chain/statements/switch.py
@@ -28,6 +28,16 @@ class SwitchStatement:
     def _add_action_for_key(self, key, action):
         self._cases.append((key, action))
 
+    def _case_for_key(self, key):
+        try:
+            return next(
+                case_action
+                for case_key, case_action in self._cases
+                if case_key == key
+            )
+        except StopIteration:
+            return None
+
     def case(self, key, *args, **kwargs):
         if not args and not kwargs:
             return CaseStatement(self, key)
@@ -43,13 +53,8 @@ class SwitchStatement:
 
     def __call__(self, context):
         key = context[self.key]
-        try:
-            action = next(
-                case_action
-                for case_key, case_action in self._cases
-                if case_key == key
-            )
-        except StopIteration:
+        action = self._case_for_key(key)
+        if action is None:
             action = self._otherwise
         if action:
             return action(context)

--- a/microcosm_pubsub/chain/statements/try_chain.py
+++ b/microcosm_pubsub/chain/statements/try_chain.py
@@ -12,30 +12,22 @@ try(
 """
 from microcosm_pubsub.chain import Chain
 from microcosm_pubsub.chain.statements.case import CaseStatement
+from microcosm_pubsub.chain.statements.switch import SwitchStatement
 
 
-class TryChainStatement:
+class TryChainStatement(SwitchStatement):
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.chain = Chain.make(*args, **kwargs)
-        self._cases = dict()
-        self._otherwise = None
 
     def catch(self, key, *args,  **kwargs):
-        if not args and not kwargs:
-            return CaseStatement(self, key)
-
-        self._cases[key] = Chain.make(*args, **kwargs)
-        return self
-
-    def otherwise(self, *args, **kwargs):
-        self._otherwise = Chain.make(*args, **kwargs)
-        return self
+        return self.case(key, *args, **kwargs)
 
     def __call__(self, context):
         try:
             res = self.chain(context)
         except Exception as error:
-            handle = self._cases.get(type(error))
+            handle = self._case_for_key(type(error))
             if not handle:
                 raise error
             return handle(context)

--- a/microcosm_pubsub/chain/statements/try_chain.py
+++ b/microcosm_pubsub/chain/statements/try_chain.py
@@ -11,7 +11,6 @@ try(
 
 """
 from microcosm_pubsub.chain import Chain
-from microcosm_pubsub.chain.statements.case import CaseStatement
 from microcosm_pubsub.chain.statements.switch import SwitchStatement
 
 

--- a/microcosm_pubsub/tests/chain/statements/test_switch.py
+++ b/microcosm_pubsub/tests/chain/statements/test_switch.py
@@ -66,3 +66,26 @@ def test_empty_switch():
         chain(arg=None),
         is_(equal_to(None)),
     )
+
+def test_switch_unhashable_value():
+    chain = Chain(
+        switch("arg").case(None).then(
+            lambda: 200,
+        ).case([]).then(
+            lambda: 300,
+        ).otherwise(
+            lambda: 500,
+        ),
+    )
+    assert_that(
+        chain(arg=[]),
+        is_(equal_to(300)),
+    )
+    assert_that(
+        chain(arg=None),
+        is_(equal_to(200)),
+    )
+    assert_that(
+        chain(arg=[1]),
+        is_(equal_to(500)),
+    )

--- a/microcosm_pubsub/tests/chain/statements/test_switch.py
+++ b/microcosm_pubsub/tests/chain/statements/test_switch.py
@@ -67,6 +67,7 @@ def test_empty_switch():
         is_(equal_to(None)),
     )
 
+
 def test_switch_unhashable_value():
     chain = Chain(
         switch("arg").case(None).then(


### PR DESCRIPTION
**Why?**
The switch statement was working with an underlying dictionary of cases. This prohibits having non-hashable values in either the value evaluated in `switch` or the value compared against in each `case`.

**What?**
- Use a list of tuple instead, so we can evaluate the logical branching with `__eq__` instead of `__hash__`.
- Make `TryChain` inherit from `Switch`.

This second change item is because the first one broke `TryChainStatement`, which relies on `CaseStatement`. Since `try_chain` is really just syntactic sugar around the `switch().case()`