### PR TITLE
Fix try-chain

### DIFF
--- a/microcosm_pubsub/chain/statements/try_chain.py
+++ b/microcosm_pubsub/chain/statements/try_chain.py
@@ -16,8 +16,8 @@ from microcosm_pubsub.chain.statements.switch import SwitchStatement
 
 class TryChainStatement(SwitchStatement):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.chain = Chain.make(*args, **kwargs)
+        super().__init__(self.chain)
 
     def catch(self, key, *args,  **kwargs):
         return self.case(key, *args, **kwargs)

--- a/microcosm_pubsub/tests/chain/statements/test_try_chain.py
+++ b/microcosm_pubsub/tests/chain/statements/test_try_chain.py
@@ -106,12 +106,12 @@ def test_try_other_simplified():
 
 def test_try_complex_chain():
     def function1(exception):
-        if exception is not None:
+        if exception is ValueError:
             raise exception()
         return True
 
     def function2(exception):
-        if exception is not None:
+        if exception is ArithmeticError:
             raise exception()
         return True
 

--- a/microcosm_pubsub/tests/chain/statements/test_try_chain.py
+++ b/microcosm_pubsub/tests/chain/statements/test_try_chain.py
@@ -102,3 +102,41 @@ def test_try_other_simplified():
         chain(exception=None),
         is_(equal_to(200)),
     )
+
+
+def test_try_complex_chain():
+    def function1(exception):
+        if exception is not None:
+            raise exception()
+        return True
+
+    def function2(exception):
+        if exception is not None:
+            raise exception()
+        return True
+
+    chain = Chain(
+        try_chain(
+            function1,
+            function2,
+        ).catch(ValueError).then(
+            lambda: 501,
+        ).catch(ArithmeticError).then(
+            lambda: 502,
+        ).otherwise(
+            Chain(lambda: 200),
+        ),
+    )
+    assert_that(
+        chain(exception=ValueError),
+        is_(equal_to(501)),
+    )
+    assert_that(
+        chain(exception=ArithmeticError),
+        is_(equal_to(502)),
+    )
+
+    assert_that(
+        chain(exception=None),
+        is_(equal_to(200)),
+    )


### PR DESCRIPTION
During the refactor, TryChain was made to inherit from Switch, which
only expects a single argument in its __init__ method. This changes the
expected argument to be the entire input chain for the try-chain.

This should make sense, given that the key (the chain) for the try-chain doesn't really matter; the actual switch-case happens against the exception handling cases.