### PR TITLE
Release 1.22.0: Fix try-chain (#153)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.20.0
+current_version = 1.22.0
 commit = False
 tag = False
 

--- a/microcosm_pubsub/chain/statements/try_chain.py
+++ b/microcosm_pubsub/chain/statements/try_chain.py
@@ -16,8 +16,8 @@ from microcosm_pubsub.chain.statements.switch import SwitchStatement
 
 class TryChainStatement(SwitchStatement):
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         self.chain = Chain.make(*args, **kwargs)
+        super().__init__(self.chain)
 
     def catch(self, key, *args,  **kwargs):
         return self.case(key, *args, **kwargs)

--- a/microcosm_pubsub/tests/chain/statements/test_try_chain.py
+++ b/microcosm_pubsub/tests/chain/statements/test_try_chain.py
@@ -102,3 +102,41 @@ def test_try_other_simplified():
         chain(exception=None),
         is_(equal_to(200)),
     )
+
+
+def test_try_complex_chain():
+    def function1(exception):
+        if exception is ValueError:
+            raise exception()
+        return True
+
+    def function2(exception):
+        if exception is ArithmeticError:
+            raise exception()
+        return True
+
+    chain = Chain(
+        try_chain(
+            function1,
+            function2,
+        ).catch(ValueError).then(
+            lambda: 501,
+        ).catch(ArithmeticError).then(
+            lambda: 502,
+        ).otherwise(
+            Chain(lambda: 200),
+        ),
+    )
+    assert_that(
+        chain(exception=ValueError),
+        is_(equal_to(501)),
+    )
+    assert_that(
+        chain(exception=ArithmeticError),
+        is_(equal_to(502)),
+    )
+
+    assert_that(
+        chain(exception=None),
+        is_(equal_to(200)),
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 from setuptools import find_packages, setup
 
+
 project = "microcosm-pubsub"
-version = "1.20.0"
+version = "1.22.0"
 
 setup(
     name=project,


### PR DESCRIPTION
During the refactor, TryChain was made to inherit from Switch, which only
expects a single argument in its __init__ method. This changes the
expected argument to be the entire input chain for the try-chain.