### PR TITLE
Supply URI in the ChainURIHandler's context

### DIFF
--- a/microcosm_pubsub/handlers/chain_handlers.py
+++ b/microcosm_pubsub/handlers/chain_handlers.py
@@ -32,7 +32,10 @@ class ChainURIHandler(URIHandler, metaclass=ABCMeta):
         return "resource"
 
     def handle(self, message, uri, resource):
-        kwargs = dict(message=message)
+        kwargs = dict(
+            message=message,
+            uri=uri,
+        )
         kwargs[self.resource_name] = resource
         chain = self.get_chain()
         chain(**kwargs)


### PR DESCRIPTION
There are certain cases where having access to this URI is useful (e.g.
in republishing daemons), and should be symmetrically available with the
normal URIHandler.