### PR TITLE
Add metrics per-handled message batch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:2.0.0
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2019.18.1
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -28,7 +28,7 @@ defaults: &defaults
 deploy_defaults: &deploy_defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:2.0.0
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2019.18.1
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -89,7 +89,6 @@ jobs:
             eval $(aws ecr get-login --no-include-email)
             docker pull ${AWS_ECR_DOMAIN}/python-library:${CIRCLE_SHA1}
             docker run -it  --volumes-from service_tests ${AWS_ECR_DOMAIN}/python-library:${CIRCLE_SHA1} test
-
   lint:
     <<: *defaults
 
@@ -108,7 +107,6 @@ jobs:
             docker pull ${AWS_ECR_DOMAIN}/python-library:${CIRCLE_SHA1}
             docker run -it --volumes-from service_tests ${AWS_ECR_DOMAIN}/python-library:${CIRCLE_SHA1} lint
 
-
   typehinting:
     <<: *defaults
 
@@ -126,7 +124,6 @@ jobs:
             eval $(aws ecr get-login --no-include-email)
             docker pull ${AWS_ECR_DOMAIN}/python-library:${CIRCLE_SHA1}
             docker run -it --volumes-from service_tests ${AWS_ECR_DOMAIN}/python-library:${CIRCLE_SHA1} typehinting
-
   deploy_pypi:
     <<: *defaults
     steps:
@@ -195,4 +192,5 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+(\.[0-9]+)*/
+
 

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -1,7 +1,10 @@
 {
   "params": {
-    "name": "microcosm-pubsub"
+    "name": "microcosm-pubsub",
+    "pypi": {
+      "repository": "pypi"
+    }
   },
   "type": "python-library",
-  "version": "2.0.36"
+  "version": "2019.18.1"
 }

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,7 +20,7 @@ FROM <REPO>/python-library:base-<SHA1>
 # to customize the `dev` and `test` targets.
 
 ENV NAME microcosm_pubsub
-COPY README.md entrypoint.sh /src/
+COPY entrypoint.sh /src/
 ENTRYPOINT ["./entrypoint.sh"]
 
 # Install source

--- a/build.python-library/docker-base/Dockerfile.template
+++ b/build.python-library/docker-base/Dockerfile.template
@@ -51,7 +51,7 @@ ENV LC_ALL en_US.UTF-8
 # These are enough to install dependencies and have a stable base layer
 # when source code changes.
 
-COPY MANIFEST.in setup.cfg setup.py /src/
+COPY README.md MANIFEST.in setup.cfg setup.py /src/
 
 RUN pip install --upgrade --extra-index-url ${EXTRA_INDEX_URL} /src/ && \
     apt-get remove --purge -y ${BUILD_PACKAGES} && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,17 +22,17 @@
 if [ "$1" = "test" ]; then
     # Install standard test dependencies; YMMV
     pip --quiet install \
-        .[test] nose mock PyHamcrest coverage
+        .[test] nose PyHamcrest coverage
     exec nosetests ${NAME}
 elif [ "$1" = "lint" ]; then
     # Install standard linting dependencies; YMMV
     pip --quiet install \
-        .[lint] flake8 flake8-print flake8-logging-format
+        .[lint] flake8 flake8-print flake8-logging-format flake8-isort
     exec flake8 ${NAME}
 elif [ "$1" = "typehinting" ]; then
     # Install standard type-linting dependencies
     pip --quiet install mypy
-    exec mypy ${NAME} --ignore-missing-imports
+    mypy ${NAME} --ignore-missing-imports
 else
     echo "Cannot execute $@"
     exit 3

--- a/microcosm_pubsub/batch.py
+++ b/microcosm_pubsub/batch.py
@@ -1,7 +1,7 @@
-from marshmallow import fields, Schema
+from marshmallow import Schema, fields
 
-from microcosm_pubsub.conventions import created
 from microcosm_pubsub.codecs import PubSubMessageSchema
+from microcosm_pubsub.conventions import created
 from microcosm_pubsub.decorators import schema
 
 

--- a/microcosm_pubsub/chain/__init__.py
+++ b/microcosm_pubsub/chain/__init__.py
@@ -6,7 +6,7 @@ from microcosm_pubsub.chain.statements import (  # noqa: F401
     assign_function,
     extract,
     for_each,
-    when,
     switch,
     try_chain,
+    when,
 )

--- a/microcosm_pubsub/chain/chain.py
+++ b/microcosm_pubsub/chain/chain.py
@@ -1,10 +1,10 @@
 from microcosm_pubsub.chain.context import SafeContext
 from microcosm_pubsub.chain.context_decorators import (
+    DEFAULT_ASSIGNED,
     get_from_context,
     save_to_context,
     save_to_context_by_func_name,
     temporarily_replace_context_keys,
-    DEFAULT_ASSIGNED,
 )
 
 

--- a/microcosm_pubsub/chain/context_decorators.py
+++ b/microcosm_pubsub/chain/context_decorators.py
@@ -1,7 +1,7 @@
-from functools import wraps, WRAPPER_ASSIGNMENTS
-from inspect import Parameter, signature, Signature
+from functools import WRAPPER_ASSIGNMENTS, wraps
+from inspect import Parameter, Signature, signature
 
-from microcosm_pubsub.chain.decorators import EXTRACTS, BINDS
+from microcosm_pubsub.chain.decorators import BINDS, EXTRACTS
 
 
 DEFAULT_ASSIGNED = (EXTRACTS, BINDS)

--- a/microcosm_pubsub/chain/decorators.py
+++ b/microcosm_pubsub/chain/decorators.py
@@ -1,5 +1,5 @@
-from inspect import ismethod
 from functools import wraps
+from inspect import ismethod
 
 
 EXTRACTS = "_extracts"

--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -4,7 +4,7 @@ Message encoding and decoding.
 """
 from json import dumps, loads
 
-from marshmallow import fields, Schema, ValidationError
+from marshmallow import Schema, ValidationError, fields
 
 
 DEFAULT_MEDIA_TYPE = "application/json"

--- a/microcosm_pubsub/conventions/__init__.py
+++ b/microcosm_pubsub/conventions/__init__.py
@@ -5,8 +5,8 @@ Convention-driven pubsub.
 from functools import partial
 
 from microcosm_pubsub.conventions.lifecycle import LifecycleChange
-from microcosm_pubsub.conventions.messages import IdentityMessageSchema, URIMessageSchema  # noqa: F401
-from microcosm_pubsub.conventions.naming import make_media_type, name_for  # noqa: F401
+from microcosm_pubsub.conventions.messages import IdentityMessageSchema, URIMessageSchema  # noqa
+from microcosm_pubsub.conventions.naming import make_media_type, name_for  # noqa
 
 
 def media_type(lifecycle_change):

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -6,8 +6,8 @@ from microcosm.loaders import load_each, load_from_dict
 from microcosm_daemon.api import SleepNow
 from microcosm_daemon.daemon import Daemon
 
-from microcosm_pubsub.envelope import SQSEnvelope, NaiveSQSEnvelope
 from microcosm_pubsub.consumer import STDIN
+from microcosm_pubsub.envelope import NaiveSQSEnvelope, SQSEnvelope
 
 
 class ConsumerDaemon(Daemon):

--- a/microcosm_pubsub/decorators.py
+++ b/microcosm_pubsub/decorators.py
@@ -5,9 +5,9 @@ Fluent decorators for resources and handlers.
 from microcosm.hooks import on_resolve
 
 from microcosm_pubsub.registry import (
-    media_type_for,
     PubSubMessageSchemaRegistry,
     SQSMessageHandlerRegistry,
+    media_type_for,
 )
 
 

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -50,7 +50,7 @@ class SQSMessageDispatcher:
         ])
 
         self.logger.info(
-            f"Finished handling batch",
+            "Finished handling batch",
             extra=dict(
                 message_count=message_count,
                 **self.opaque.as_dict(),

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -10,7 +10,7 @@ from microcosm_logging.decorators import context_logger, logger
 from microcosm_logging.timing import elapsed_time
 
 from microcosm_pubsub.context import TTL_KEY
-from microcosm_pubsub.errors import IgnoreMessage, TTLExpired, SkipMessage
+from microcosm_pubsub.errors import IgnoreMessage, SkipMessage, TTLExpired
 from microcosm_pubsub.result import MessageHandlingResult
 
 

--- a/microcosm_pubsub/envelope.py
+++ b/microcosm_pubsub/envelope.py
@@ -7,8 +7,8 @@ process this envelope, depending on the degree of validation and metadata desire
 
 """
 from abc import ABCMeta, abstractmethod
-from json import loads
 from hashlib import md5
+from json import loads
 from uuid import uuid4
 
 from microcosm.api import defaults

--- a/microcosm_pubsub/handlers/chain_handlers.py
+++ b/microcosm_pubsub/handlers/chain_handlers.py
@@ -1,6 +1,7 @@
+from abc import ABCMeta, abstractmethod
+
 from microcosm_pubsub.chain import Chain
 from microcosm_pubsub.handlers.uri_handler import URIHandler
-from abc import ABCMeta, abstractmethod
 
 
 class ChainHandler(metaclass=ABCMeta):

--- a/microcosm_pubsub/handlers/publish_batch_message.py
+++ b/microcosm_pubsub/handlers/publish_batch_message.py
@@ -5,6 +5,7 @@ PublishBatchMessage handler.
 
 from microcosm.api import binding
 from microcosm_logging.decorators import logger
+
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.decorators import handles
 

--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -3,8 +3,8 @@ Uri Handler base classes.
 
 """
 from abc import ABCMeta
-from inflection import titleize
 
+from inflection import titleize
 from requests import codes, get
 
 from microcosm_pubsub.errors import Nack

--- a/microcosm_pubsub/main.py
+++ b/microcosm_pubsub/main.py
@@ -3,6 +3,7 @@ PubSub CLI
 
 """
 from __future__ import print_function
+
 from argparse import ArgumentParser
 from json import dumps
 from sys import stdout
@@ -10,7 +11,7 @@ from sys import stdout
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_dict
 
-from microcosm_pubsub.conventions import created, changed
+from microcosm_pubsub.conventions import changed, created
 
 
 def main():

--- a/microcosm_pubsub/matchers/__init__.py
+++ b/microcosm_pubsub/matchers/__init__.py
@@ -9,10 +9,10 @@ this package as part of their unit tests (and not their runtime).
 
 """
 from microcosm_pubsub.matchers.message import (
-    has_media_type,
-    has_uri,
     PublishedMessage,
     PublishedMessageMatcher,
+    has_media_type,
+    has_uri,
 )
 from microcosm_pubsub.matchers.publishing import (
     published,

--- a/microcosm_pubsub/matchers/message.py
+++ b/microcosm_pubsub/matchers/message.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from json import loads
-from typing import Iterable, Optional, Mapping
+from typing import Iterable, Mapping, Optional
 from unittest.mock import Mock
 
 from hamcrest import not_none

--- a/microcosm_pubsub/matchers/publishing.py
+++ b/microcosm_pubsub/matchers/publishing.py
@@ -5,8 +5,10 @@ Matchers for message publishing.
 from typing import List
 
 from hamcrest.core.helpers.wrap_matcher import wrap_matcher
+from hamcrest.library.collection.issequence_containinginanyorder import (
+    IsSequenceContainingInAnyOrder,
+)
 from hamcrest.library.collection.issequence_containinginorder import IsSequenceContainingInOrder
-from hamcrest.library.collection.issequence_containinginanyorder import IsSequenceContainingInAnyOrder
 
 from microcosm_pubsub.matchers.message import PublishedMessage
 

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,6 +1,7 @@
 from microcosm.api import defaults, typed
-from microcosm.errors import NotBoundError
 from microcosm.config.types import boolean
+from microcosm.errors import NotBoundError
+
 from microcosm_pubsub.result import MessageHandlingResultType
 
 

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -100,7 +100,7 @@ class PubSubSendBatchMetrics:
         )
 
         self.metrics.histogram(
-            "message_count",
+            "message_batch_count",
             message_count,
             tags=tags,
         )

--- a/microcosm_pubsub/reader.py
+++ b/microcosm_pubsub/reader.py
@@ -2,8 +2,8 @@
 Implement SQS message reading from other sources.
 
 """
-from sys import stdin
 from json import loads
+from sys import stdin
 
 from microcosm_daemon.error_policy import ExitError
 

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -6,9 +6,19 @@ from dataclasses import dataclass, field
 from enum import Enum, unique
 from logging import DEBUG, INFO, WARNING
 from sys import exc_info
-from typing import Any, Dict, Optional, Tuple
+from typing import (
+    Any,
+    Dict,
+    Optional,
+    Tuple,
+)
 
-from microcosm_pubsub.errors import IgnoreMessage, Nack, SkipMessage, TTLExpired
+from microcosm_pubsub.errors import (
+    IgnoreMessage,
+    Nack,
+    SkipMessage,
+    TTLExpired,
+)
 from microcosm_pubsub.message import SQSMessage
 
 

--- a/microcosm_pubsub/tests/chain/statements/test_assign.py
+++ b/microcosm_pubsub/tests/chain/statements/test_assign.py
@@ -1,9 +1,4 @@
-from hamcrest import (
-    assert_that,
-    equal_to,
-    is_,
-)
-
+from hamcrest import assert_that, equal_to, is_
 
 from microcosm_pubsub.chain import Chain
 from microcosm_pubsub.chain.statements import (

--- a/microcosm_pubsub/tests/chain/statements/test_for_each.py
+++ b/microcosm_pubsub/tests/chain/statements/test_for_each.py
@@ -1,13 +1,7 @@
-from hamcrest import (
-    assert_that,
-    equal_to,
-    is_,
-)
+from hamcrest import assert_that, equal_to, is_
 
 from microcosm_pubsub.chain import Chain
-from microcosm_pubsub.chain.statements import (
-    for_each,
-)
+from microcosm_pubsub.chain.statements import for_each
 
 
 def test_for_each():

--- a/microcosm_pubsub/tests/chain/statements/test_switch.py
+++ b/microcosm_pubsub/tests/chain/statements/test_switch.py
@@ -1,13 +1,7 @@
-from hamcrest import (
-    assert_that,
-    equal_to,
-    is_,
-)
+from hamcrest import assert_that, equal_to, is_
 
 from microcosm_pubsub.chain import Chain
-from microcosm_pubsub.chain.statements import (
-    switch,
-)
+from microcosm_pubsub.chain.statements import switch
 
 
 def test_switch():

--- a/microcosm_pubsub/tests/chain/statements/test_try_chain.py
+++ b/microcosm_pubsub/tests/chain/statements/test_try_chain.py
@@ -7,9 +7,7 @@ from hamcrest import (
 )
 
 from microcosm_pubsub.chain import Chain
-from microcosm_pubsub.chain.statements import (
-    try_chain,
-)
+from microcosm_pubsub.chain.statements import try_chain
 
 
 def test_try_chain():

--- a/microcosm_pubsub/tests/chain/statements/test_when.py
+++ b/microcosm_pubsub/tests/chain/statements/test_when.py
@@ -1,13 +1,7 @@
-from hamcrest import (
-    assert_that,
-    equal_to,
-    is_,
-)
+from hamcrest import assert_that, equal_to, is_
 
 from microcosm_pubsub.chain import Chain
-from microcosm_pubsub.chain.statements import (
-    when,
-)
+from microcosm_pubsub.chain.statements import when
 
 
 def test_when():

--- a/microcosm_pubsub/tests/chain/test_chain.py
+++ b/microcosm_pubsub/tests/chain/test_chain.py
@@ -1,11 +1,7 @@
-from hamcrest import (
-    assert_that,
-    equal_to,
-    is_,
-)
+from hamcrest import assert_that, equal_to, is_
 
 from microcosm_pubsub.chain import Chain
-from microcosm_pubsub.chain.decorators import extracts, binds
+from microcosm_pubsub.chain.decorators import binds, extracts
 
 
 class TestChain:

--- a/microcosm_pubsub/tests/chain/test_decorators.py
+++ b/microcosm_pubsub/tests/chain/test_decorators.py
@@ -6,13 +6,13 @@ from hamcrest import (
     raises,
 )
 
-from microcosm_pubsub.chain.decorators import binds, extracts
 from microcosm_pubsub.chain.context_decorators import (
     get_from_context,
     save_to_context,
     save_to_context_by_func_name,
     temporarily_replace_context_keys,
 )
+from microcosm_pubsub.chain.decorators import binds, extracts
 
 
 class TestDecorators:

--- a/microcosm_pubsub/tests/conventions/test_conventions.py
+++ b/microcosm_pubsub/tests/conventions/test_conventions.py
@@ -2,9 +2,14 @@
 Test conventions.
 
 """
-from hamcrest import assert_that, equal_to, instance_of, is_
-
+from hamcrest import (
+    assert_that,
+    equal_to,
+    instance_of,
+    is_,
+)
 from microcosm.api import create_object_graph
+
 from microcosm_pubsub.conventions import created, deleted, media_type
 from microcosm_pubsub.conventions.messages import IdentityMessageSchema, URIMessageSchema
 

--- a/microcosm_pubsub/tests/conventions/test_messages.py
+++ b/microcosm_pubsub/tests/conventions/test_messages.py
@@ -8,23 +8,20 @@ from hamcrest import (
     assert_that,
     equal_to,
     instance_of,
-    is_
+    is_,
 )
 from microcosm.api import create_object_graph
 
 from microcosm_pubsub.codecs import PubSubMessageCodec
 from microcosm_pubsub.conventions import (
-    created,
-    deleted,
     IdentityMessageSchema,
     LifecycleChange,
-    make_media_type,
     URIMessageSchema,
+    created,
+    deleted,
+    make_media_type,
 )
-from microcosm_pubsub.tests.fixtures import (
-    ExampleDaemon,
-    noop_handler,
-)
+from microcosm_pubsub.tests.fixtures import ExampleDaemon, noop_handler
 
 
 class Foo:

--- a/microcosm_pubsub/tests/conventions/test_naming.py
+++ b/microcosm_pubsub/tests/conventions/test_naming.py
@@ -2,11 +2,8 @@
 Naming tests.
 
 """
-from hamcrest import (
-    assert_that,
-    equal_to,
-    is_
-)
+from hamcrest import assert_that, equal_to, is_
+
 from microcosm_pubsub.conventions import make_media_type
 
 

--- a/microcosm_pubsub/tests/fixtures.py
+++ b/microcosm_pubsub/tests/fixtures.py
@@ -2,9 +2,9 @@
 Test fixtures.
 
 """
-from marshmallow import fields, Schema
-
+from marshmallow import Schema, fields
 from microcosm.api import binding
+
 from microcosm_pubsub.codecs import PubSubMessageSchema
 from microcosm_pubsub.conventions import created, deleted
 from microcosm_pubsub.daemon import ConsumerDaemon
@@ -38,8 +38,8 @@ class DuckTypeSchema(Schema):
 
 
 @handles(DuckTypeSchema)
-@handles(created("foo"))
-@handles(deleted("foo"))
+@handles(created("Foo"))
+@handles(deleted("Foo"))
 @handles(DerivedSchema.MEDIA_TYPE)
 def noop_handler(message):
     return True

--- a/microcosm_pubsub/tests/handlers/test_uri_handler.py
+++ b/microcosm_pubsub/tests/handlers/test_uri_handler.py
@@ -1,6 +1,11 @@
 from unittest.mock import MagicMock, patch
 
-from hamcrest import assert_that, equal_to, instance_of, is_
+from hamcrest import (
+    assert_that,
+    equal_to,
+    instance_of,
+    is_,
+)
 from microcosm.api import create_object_graph
 
 from microcosm_pubsub.handlers import URIHandler

--- a/microcosm_pubsub/tests/test_backoff.py
+++ b/microcosm_pubsub/tests/test_backoff.py
@@ -2,8 +2,9 @@
 Test backoff policies.
 
 """
-from hamcrest import assert_that, equal_to, is_
 from unittest.mock import patch
+
+from hamcrest import assert_that, equal_to, is_
 
 from microcosm_pubsub.backoff import ExponentialBackoffPolicy, NaiveBackoffPolicy
 from microcosm_pubsub.message import SQSMessage

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -7,8 +7,8 @@ from json import dumps
 from hamcrest import (
     assert_that,
     equal_to,
-    is_,
     has_length,
+    is_,
 )
 
 from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon

--- a/microcosm_pubsub/tests/test_context.py
+++ b/microcosm_pubsub/tests/test_context.py
@@ -2,10 +2,7 @@
 SQSMessageContext tests.
 
 """
-from hamcrest import (
-    assert_that,
-    has_entries,
-)
+from hamcrest import assert_that, has_entries
 
 from microcosm_pubsub.message import SQSMessage
 from microcosm_pubsub.tests.fixtures import ExampleDaemon

--- a/microcosm_pubsub/tests/test_decorators.py
+++ b/microcosm_pubsub/tests/test_decorators.py
@@ -9,11 +9,7 @@ from hamcrest import (
     is_,
 )
 
-from microcosm_pubsub.tests.fixtures import (
-    DuckTypeSchema,
-    ExampleDaemon,
-    noop_handler,
-)
+from microcosm_pubsub.tests.fixtures import DuckTypeSchema, ExampleDaemon, noop_handler
 
 
 class TestDecorators:

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -3,19 +3,13 @@ Dispatcher tests.
 
 """
 from json import dumps
-from hamcrest import (
-    assert_that,
-    greater_than,
-    has_properties,
-)
+
+from hamcrest import assert_that, greater_than, has_properties
 
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.message import SQSMessage
 from microcosm_pubsub.result import MessageHandlingResultType
-from microcosm_pubsub.tests.fixtures import (
-    ExampleDaemon,
-    DerivedSchema,
-)
+from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon
 
 
 MESSAGE_ID = "message-id"

--- a/microcosm_pubsub/tests/test_envelope.py
+++ b/microcosm_pubsub/tests/test_envelope.py
@@ -4,18 +4,11 @@ SQS envelope tests.
 """
 from json import dumps
 
-from hamcrest import (
-    assert_that,
-    equal_to,
-    is_,
-)
-
+from hamcrest import assert_that, equal_to, is_
 from microcosm.api import create_object_graph
+
 from microcosm_pubsub.conventions import created
-from microcosm_pubsub.envelope import (
-    CodecSQSEnvelope,
-    RawSQSEnvelope,
-)
+from microcosm_pubsub.envelope import CodecSQSEnvelope, RawSQSEnvelope
 
 
 def test_raw_sqs_envelope():

--- a/microcosm_pubsub/tests/test_fields.py
+++ b/microcosm_pubsub/tests/test_fields.py
@@ -3,6 +3,7 @@ Test fields
 
 """
 from uuid import UUID
+
 from hamcrest import (
     assert_that,
     contains,

--- a/microcosm_pubsub/tests/test_matcher.py
+++ b/microcosm_pubsub/tests/test_matcher.py
@@ -2,7 +2,7 @@
 Test customized matcher.
 
 """
-from hamcrest import assert_that, all_of
+from hamcrest import all_of, assert_that
 from microcosm.api import create_object_graph, load_from_dict
 
 from microcosm_pubsub.conventions import created

--- a/microcosm_pubsub/tests/test_metrics.py
+++ b/microcosm_pubsub/tests/test_metrics.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from hamcrest import assert_that, equal_to, is_
 from microcosm.api import create_object_graph, load_from_dict
 
-from microcosm_pubsub.metrics import PubSubSendMetrics
+from microcosm_pubsub.metrics import PubSubSendBatchMetrics, PubSubSendMetrics
 
 
 def test_configure_metrics_default_metrics_not_installed():
@@ -58,3 +58,53 @@ def test_configure_metrics_disable():
     )
     graph = create_object_graph("example", testing=True, loader=loader)
     assert_that(graph.pubsub_send_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_batch_metrics_default_metrics_not_installed():
+    """
+    Disable metrics by default if metrics not installed.
+
+    """
+    with patch.object(PubSubSendBatchMetrics, "get_metrics") as mocked:
+        mocked.return_value = None
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_batch_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_batch_metrics_default_metrics_installed():
+    """
+    Enabled metrics by default if installed.
+
+    """
+    with patch.object(PubSubSendBatchMetrics, "get_metrics") as mocked:
+        mocked.return_value = Mock(host="localhost")
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_batch_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_batch_metrics_default_metrics_configured():
+    """
+    Enabled metrics by default if installed.
+
+    """
+    with patch.object(PubSubSendBatchMetrics, "get_metrics") as mocked:
+        mocked.return_value = Mock(host="statsd")
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_batch_metrics.enabled, is_(equal_to(True)))
+
+
+def test_configure_batch_metrics_disable():
+    """
+    Disable metrics explicitly.
+
+    """
+    loader = load_from_dict(
+        pubsub_send_batch_metrics=dict(
+            enabled=False,
+        ),
+    )
+    graph = create_object_graph("example", testing=True, loader=loader)
+    assert_that(graph.pubsub_send_batch_metrics.enabled, is_(equal_to(False)))

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -5,6 +5,7 @@ Producer tests.
 from json import loads
 from os import environ
 
+import microcosm.opaque  # noqa
 from hamcrest import (
     assert_that,
     calling,
@@ -15,16 +16,15 @@ from hamcrest import (
 )
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_environ
-import microcosm.opaque  # noqa
 
 from microcosm_pubsub.batch import MessageBatchSchema
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.errors import TopicNotDefinedError
 from microcosm_pubsub.producer import (
+    DeferredBatchProducer,
+    DeferredProducer,
     deferred,
     deferred_batch,
-    DeferredProducer,
-    DeferredBatchProducer,
     iter_topic_mappings,
 )
 from microcosm_pubsub.tests.fixtures import DerivedSchema

--- a/microcosm_pubsub/tests/test_registry.py
+++ b/microcosm_pubsub/tests/test_registry.py
@@ -10,14 +10,9 @@ from hamcrest import (
     is_,
     raises,
 )
-from microcosm.api import create_object_graph
-from microcosm.api import binding
+from microcosm.api import binding, create_object_graph
 
-from microcosm_pubsub.codecs import (
-    DEFAULT_MEDIA_TYPE,
-    PubSubMessageCodec,
-    PubSubMessageSchema,
-)
+from microcosm_pubsub.codecs import DEFAULT_MEDIA_TYPE, PubSubMessageCodec, PubSubMessageSchema
 from microcosm_pubsub.registry import AlreadyRegisteredError
 from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon, noop_handler
 

--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -5,7 +5,12 @@ Test result handling.
 from hamcrest import assert_that, has_entries, has_properties
 from microcosm_logging.decorators import logger
 
-from microcosm_pubsub.errors import IgnoreMessage, Nack, SkipMessage, TTLExpired
+from microcosm_pubsub.errors import (
+    IgnoreMessage,
+    Nack,
+    SkipMessage,
+    TTLExpired,
+)
 from microcosm_pubsub.message import SQSMessage
 from microcosm_pubsub.result import MessageHandlingResult, MessageHandlingResultType
 from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,13 +5,14 @@ max-complexity = 15
 [isort]
 combine_as_imports = True
 enforce_white_space = True
+force_grid_wrap = 4
+include_trailing_comma = True
+known_first_party = microcosm-pubsub
 known_standard_library = pkg_resources,dataclasses
 known_third_party = six,hamcrest,nose_parameterized,microcosm,unidecode,nose
-line_length = 120
+line_length = 99
 lines_after_imports = 2
 multi_line_output = 3
-include_trailing_comma = True
-force_grid_wrap = 8
 
 [mypy]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "microcosm.factories": [
             "pubsub_message_schema_registry = microcosm_pubsub.registry:configure_schema_registry",
             "pubsub_lifecycle_change = microcosm_pubsub.conventions:LifecycleChange",
+            "pubsub_send_batch_metrics = microcosm_pubsub.metrics:PubSubSendBatchMetrics",
             "pubsub_send_metrics = microcosm_pubsub.metrics:PubSubSendMetrics",
             "sqs_message_context = microcosm_pubsub.context:SQSMessageContext",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",


### PR DESCRIPTION
Adds two new metrics: the time needed to process a batch of messages,
and the count of relevant messages per batch.

The previous metrics, while useful for per-message handling statistics,
weren't useful enough when trying to analyze message-handling from the
consumer's viewpoint. For example, it would be difficult to see how
long, under load, it took for any given service to handle a batch of
messages.