### PR TITLE
Add metrics per-handled message batch

### DIFF
--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -50,7 +50,7 @@ class SQSMessageDispatcher:
         ])
 
         self.logger.info(
-            f"Finished handling batch",
+            "Finished handling batch",
             extra=dict(
                 message_count=message_count,
                 **self.opaque.as_dict(),

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -2,6 +2,7 @@
 Process batches of messages.
 
 """
+from logging import Logger
 from typing import List
 
 from inflection import titleize
@@ -24,6 +25,8 @@ class SQSMessageDispatcher:
     Dispatch batches of SQSMessages to handler functions.
 
     """
+    logger: Logger
+
     def __init__(self, graph):
         self.opaque = graph.opaque
         self.sqs_consumer = graph.sqs_consumer

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -100,7 +100,7 @@ class PubSubSendBatchMetrics:
         )
 
         self.metrics.histogram(
-            "message_count",
+            "message_batch_count",
             message_count,
             tags=tags,
         )

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
 from microcosm.errors import NotBoundError

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-from datadog.dogstatsd.base import DogStatsd
 from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
 from microcosm.errors import NotBoundError
@@ -69,7 +68,7 @@ class PubSubSendBatchMetrics:
             and graph.config.pubsub_send_metrics.enabled
         )
 
-    def get_metrics(self, graph) -> Optional[DogStatsd]:
+    def get_metrics(self, graph):
         """
         Fetch the metrics client from the graph.
 

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -9,6 +9,10 @@ from microcosm_pubsub.result import MessageHandlingResultType
     enabled=typed(boolean, default_value=True)
 )
 class PubSubSendMetrics:
+    """
+    Send metrics relating to a single MessageHandlingResult
+
+    """
 
     def __init__(self, graph):
         self.metrics = self.get_metrics(graph)
@@ -57,6 +61,10 @@ class PubSubSendMetrics:
     enabled=typed(boolean, default_value=True)
 )
 class PubSubSendBatchMetrics:
+    """
+    Send metrics relating to a batch of handled messages
+
+    """
 
     def __init__(self, graph):
         self.metrics = self.get_metrics(graph)
@@ -78,7 +86,7 @@ class PubSubSendBatchMetrics:
         except NotBoundError:
             return None
 
-    def __call__(self, elapsed_time, message_count: int):
+    def __call__(self, elapsed_time: float, message_count: int):
         """
         Send metrics if enabled.
 

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from datadog.dogstatsd.base import DogStatsd
 from microcosm.api import defaults, typed

--- a/microcosm_pubsub/tests/test_metrics.py
+++ b/microcosm_pubsub/tests/test_metrics.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from hamcrest import assert_that, equal_to, is_
 from microcosm.api import create_object_graph, load_from_dict
 
-from microcosm_pubsub.metrics import PubSubSendMetrics
+from microcosm_pubsub.metrics import PubSubSendBatchMetrics, PubSubSendMetrics
 
 
 def test_configure_metrics_default_metrics_not_installed():
@@ -58,3 +58,53 @@ def test_configure_metrics_disable():
     )
     graph = create_object_graph("example", testing=True, loader=loader)
     assert_that(graph.pubsub_send_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_batch_metrics_default_metrics_not_installed():
+    """
+    Disable metrics by default if metrics not installed.
+
+    """
+    with patch.object(PubSubSendBatchMetrics, "get_metrics") as mocked:
+        mocked.return_value = None
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_batch_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_batch_metrics_default_metrics_installed():
+    """
+    Enabled metrics by default if installed.
+
+    """
+    with patch.object(PubSubSendBatchMetrics, "get_metrics") as mocked:
+        mocked.return_value = Mock(host="localhost")
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_batch_metrics.enabled, is_(equal_to(False)))
+
+
+def test_configure_batch_metrics_default_metrics_configured():
+    """
+    Enabled metrics by default if installed.
+
+    """
+    with patch.object(PubSubSendBatchMetrics, "get_metrics") as mocked:
+        mocked.return_value = Mock(host="statsd")
+
+        graph = create_object_graph("example", testing=True)
+        assert_that(graph.pubsub_send_batch_metrics.enabled, is_(equal_to(True)))
+
+
+def test_configure_batch_metrics_disable():
+    """
+    Disable metrics explicitly.
+
+    """
+    loader = load_from_dict(
+        pubsub_send_batch_metrics=dict(
+            enabled=False,
+        ),
+    )
+    graph = create_object_graph("example", testing=True, loader=loader)
+    assert_that(graph.pubsub_send_batch_metrics.enabled, is_(equal_to(False)))

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "microcosm.factories": [
             "pubsub_message_schema_registry = microcosm_pubsub.registry:configure_schema_registry",
             "pubsub_lifecycle_change = microcosm_pubsub.conventions:LifecycleChange",
+            "pubsub_send_batch_metrics = microcosm_pubsub.metrics:PubSubSendBatchMetrics",
             "pubsub_send_metrics = microcosm_pubsub.metrics:PubSubSendMetrics",
             "sqs_message_context = microcosm_pubsub.context:SQSMessageContext",
             "sqs_consumer = microcosm_pubsub.consumer:configure_sqs_consumer",


### PR DESCRIPTION
Adds two new metrics: the time needed to process a batch of messages, and
the count of relevant messages per batch.

The previous metrics, while useful for per-message handling statistics,
weren't useful enough when trying to analyze message-handling from the
consumer's viewpoint. For example, it would be difficult to see how long,
under load, it took for any given service to handle a batch of messages.