### PR TITLE
Hotfix 1.24.1 Fix metric name / log message

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.24.0
+current_version = 1.24.1
 commit = False
 tag = False
 

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -57,13 +57,12 @@ class SQSMessageDispatcher:
         ])
 
         if message_count > 0:
-            self.logger.info(
-                "Finished handling batch: Message count: {message_count}, elapsed_time: {batch_elapsed_time}",
-                extra=dict(
-                    message_count=message_count,
-                    batch_elapsed_time=batch_elapsed_time,
-                ),
+            # NB: Expose formatted message
+            message = "Completed batch: Message count: {message_count}, elapsed_time: {batch_elapsed_time}".format(
+                message_count=message_count,
+                batch_elapsed_time=batch_elapsed_time,
             )
+            self.logger.info(message)
 
         self.send_batch_metrics(batch_elapsed_time, message_count)
 

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -51,20 +51,20 @@ class SQSMessageDispatcher:
 
         batch_elapsed_time = time() - start_time
 
-        message_count = len([
+        message_batch_size = len([
             instance for instance in instances
             if instance.result != MessageHandlingResultType.IGNORED
         ])
 
-        if message_count > 0:
+        if message_batch_size > 0:
             # NB: Expose formatted message
-            message = "Completed batch: Message count: {message_count}, elapsed_time: {batch_elapsed_time}".format(
-                message_count=message_count,
+            message = "Completed batch: Message count: {message_batch_size}, elapsed_time: {batch_elapsed_time}".format(
+                message_batch_size=message_batch_size,
                 batch_elapsed_time=batch_elapsed_time,
             )
             self.logger.info(message)
 
-        self.send_batch_metrics(batch_elapsed_time, message_count)
+        self.send_batch_metrics(batch_elapsed_time, message_batch_size)
 
         for instance in instances:
             self.send_metrics(instance)

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -86,7 +86,7 @@ class PubSubSendBatchMetrics:
         except NotBoundError:
             return None
 
-    def __call__(self, elapsed_time: float, message_count: int):
+    def __call__(self, elapsed_time: float, message_batch_size: int):
         """
         Send metrics if enabled.
 
@@ -105,7 +105,7 @@ class PubSubSendBatchMetrics:
         )
 
         self.metrics.histogram(
-            "message_batch_count",
-            message_count,
+            "message_batch_size",
+            message_batch_size,
             tags=tags,
         )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "1.24.0"
+version = "1.24.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Use a preformatted message for batch message counts

This was otherwise preventing the message parameters from being exposed in
our log aggregator, which made this message less than useful.

Also fix the metric name; <metric>_count appears to be an implicitly stored value.