### PR TITLE
Add metrics for detecting when a message has started being handled

### DIFF
--- a/microcosm_pubsub/constants.py
+++ b/microcosm_pubsub/constants.py
@@ -3,5 +3,6 @@ Constants.
 
 """
 
+PUBLISHED_KEY = "X-Request-Published"
 TTL_KEY = "X-Request-Ttl"
 URI_KEY = "uri"

--- a/microcosm_pubsub/main.py
+++ b/microcosm_pubsub/main.py
@@ -136,5 +136,5 @@ def make_naive_message():
     args = parser.parse_args()
 
     action = dict(created=created, changed=changed)[args.action]
-    from time import time
-    write(dumps(dict(mediaType=action(args.resource_name), opaque={"X-Request-Published": time()}, uri=args.uri)))
+
+    stdout.write(dumps(dict(mediaType=action(args.resource_name), uri=args.uri)))

--- a/microcosm_pubsub/main.py
+++ b/microcosm_pubsub/main.py
@@ -136,5 +136,5 @@ def make_naive_message():
     args = parser.parse_args()
 
     action = dict(created=created, changed=changed)[args.action]
-
-    stdout.write(dumps(dict(mediaType=action(args.resource_name), uri=args.uri)))
+    from time import time
+    write(dumps(dict(mediaType=action(args.resource_name), opaque={"X-Request-Published": time()}, uri=args.uri)))

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -2,7 +2,7 @@ from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
 from microcosm.errors import NotBoundError
 
-from microcosm_pubsub.result import MessageHandlingResultType
+from microcosm_pubsub.result import MessageHandlingResult, MessageHandlingResultType
 
 
 @defaults(
@@ -34,13 +34,13 @@ class PubSubSendMetrics:
         except NotBoundError:
             return None
 
-    def __call__(self, result):
+    def __call__(self, result: MessageHandlingResult):
         """
         Send metrics if enabled.
 
         """
-        if not self.enabled:
-            return
+        # if not self.enabled:
+        #     return
 
         if result.result == MessageHandlingResultType.IGNORED:
             return
@@ -55,6 +55,14 @@ class PubSubSendMetrics:
             result.elapsed_time,
             tags=tags,
         )
+
+        print(result.handle_start_time)
+        if result.handle_start_time:
+            self.metrics.histogram(
+                "message_start",
+                result.handle_start_time,
+                tags=tags,
+            )
 
 
 @defaults(

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -58,7 +58,7 @@ class PubSubSendMetrics:
 
         if result.handle_start_time:
             self.metrics.histogram(
-                "message_start",
+                "message_handle_start",
                 result.handle_start_time,
                 tags=tags,
             )

--- a/microcosm_pubsub/metrics.py
+++ b/microcosm_pubsub/metrics.py
@@ -39,8 +39,8 @@ class PubSubSendMetrics:
         Send metrics if enabled.
 
         """
-        # if not self.enabled:
-        #     return
+        if not self.enabled:
+            return
 
         if result.result == MessageHandlingResultType.IGNORED:
             return
@@ -56,7 +56,6 @@ class PubSubSendMetrics:
             tags=tags,
         )
 
-        print(result.handle_start_time)
         if result.handle_start_time:
             self.metrics.histogram(
                 "message_start",

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -5,6 +5,7 @@ Message producer.
 from collections import defaultdict
 from distutils.util import strtobool
 from functools import wraps
+from time import time
 
 from boto3 import Session
 from microcosm.api import defaults, typed
@@ -13,6 +14,7 @@ from microcosm_logging.decorators import logger
 from microcosm_logging.timing import elapsed_time
 
 from microcosm_pubsub.batch import MessageBatchSchema
+from microcosm_pubsub.constants import PUBLISHED_KEY
 from microcosm_pubsub.conventions.naming import make_media_type
 from microcosm_pubsub.errors import TopicNotDefinedError
 
@@ -50,6 +52,8 @@ class SNSProducer:
 
         if self.opaque is not None:
             opaque_data.update(self.opaque.as_dict())
+
+        opaque_data[PUBLISHED_KEY] = time()
 
         topic_arn = self.choose_topic_arn(media_type)
         message = self.pubsub_message_schema_registry.find(media_type).encode(

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -74,6 +74,7 @@ class MessageHandlingResult:
     exc_info: Optional[Tuple[Any, Any, Any]] = None
     extra: Dict[str, str] = field(default_factory=dict)
     elapsed_time: Optional[float] = None
+    handle_start_time: Optional[float] = None
     retry_timeout_seconds: Optional[int] = None
 
     @classmethod

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -85,6 +85,28 @@ class TestDispatcher:
             ),
         )
 
+    def test_handle_message_published_time(self):
+        """
+        Messages that have a published time header calculate that time
+
+        """
+        self.message.content = dict(
+            opaque_data={
+                "X-Request-Published": "0",
+            },
+        )
+        assert_that(
+            self.dispatcher.handle_message(
+                message=self.message,
+                bound_handlers=self.daemon.bound_handlers,
+            ),
+            has_properties(
+                handle_start_time=greater_than(0.0),
+                elapsed_time=greater_than(0.0),
+                result=MessageHandlingResultType.SUCCEEDED,
+            ),
+        )
+
     def test_handle_message_reached_processing_limit(self):
         """
         Messages that have reached the processing limit are ignored


### PR DESCRIPTION
This metrics tracks when a given message was produced, and when it
actually got dispatched to a given handler. This should help track to
see if there are significant delays between message publish and
consumption, which would help to see if we should tune batch sizing /
daemon counts / etc.