### PR TITLE
Enable message attributes + raw message parsing

### DIFF
--- a/microcosm_pubsub/batch.py
+++ b/microcosm_pubsub/batch.py
@@ -15,6 +15,7 @@ class BatchedMessageSchema(Schema):
     message = fields.Raw(required=True)
     topic_arn = fields.String(required=True)
     opaque_data = fields.Raw(required=True)
+    message_attributes = fields.Raw(required=True)
 
 
 @schema

--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -85,7 +85,11 @@ class PubSubMessageCodec:
         Uses the appropriate coded to read JSON.
 
         """
-        dct = loads(message)
+        try:
+            dct = loads(message)
+        except TypeError:
+            # message is already a dict
+            dct = message
         # we need to explicitly validate because dump() doesn't
         self.schema.validate(dct)
         decoded = self.schema.dump(dct)

--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -85,10 +85,9 @@ class PubSubMessageCodec:
         Uses the appropriate coded to read JSON.
 
         """
-        try:
+        if not isinstance(message, dict):
             dct = loads(message)
-        except TypeError:
-            # message is already a dict
+        else:
             dct = message
         # we need to explicitly validate because dump() doesn't
         self.schema.validate(dct)

--- a/microcosm_pubsub/envelope.py
+++ b/microcosm_pubsub/envelope.py
@@ -89,7 +89,12 @@ class SNSMessageBodyParser(MessageBodyParser):
         as JSON within the `Message` key of the top-level envelope.
 
         """
-        return loads(body)["Message"]
+        body_dict = loads(body)
+        try:
+            return body_dict["Message"]
+        except KeyError:
+            # We're handling a raw message
+            return body_dict
 
 
 class CodecMediaTypeAndContentParser(MediaTypeAndContentParser):

--- a/microcosm_pubsub/handlers/publish_batch_message.py
+++ b/microcosm_pubsub/handlers/publish_batch_message.py
@@ -8,6 +8,7 @@ from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.decorators import handles
+from microcosm_pubsub.producer import PubsubMessage, SNSProducer
 
 
 @binding("publish_message_batch")
@@ -16,14 +17,17 @@ from microcosm_pubsub.decorators import handles
 class PublishBatchMessage:
 
     def __init__(self, graph):
-        self.sns_producer = graph.sns_producer
+        self.sns_producer: SNSProducer = graph.sns_producer
 
     def __call__(self, message):
         messages = message["messages"]
         for message in messages:
-            self.sns_producer.publish_message(
-                message["media_type"],
-                message["message"],
-                message["topic_arn"],
-                message["opaque_data"],
+            pubsub_message = PubsubMessage(
+                media_type=message["media_type"],
+                message=message["message"],
+                message_attributes=message["message_attributes"],
+                opaque_data=message["opaque_data"],
+                topic_arn=message["topic_arn"],
             )
+
+            self.sns_producer.publish_message(pubsub_message)

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from distutils.util import strtobool
 from functools import wraps
+from logging import Logger
 from time import time
 from typing import Dict, List
 
@@ -41,6 +42,8 @@ class SNSProducer:
     Produces messages to SNS topics.
 
     """
+    logger: Logger
+
     def __init__(self, opaque, pubsub_message_schema_registry, sns_client, sns_topic_arns, skip, deferred_batch_size):
         self.opaque = opaque
         self.pubsub_message_schema_registry = pubsub_message_schema_registry

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -193,7 +193,7 @@ class DeferredBatchProducer(DeferredProducer):
             if len(message_batch) > 1:
                 self.producer.produce(
                     MessageBatchSchema.MEDIA_TYPE,
-                    messages=self.construct_batch_pubsub_message(message_batch)
+                    messages=self.construct_batch_pubsub_message(message_batch),
                 )
             elif len(message_batch) == 1:
                 self.producer.publish_message(message_batch[0])

--- a/microcosm_pubsub/tests/conventions/test_messages.py
+++ b/microcosm_pubsub/tests/conventions/test_messages.py
@@ -144,6 +144,13 @@ def test_publish_by_uri_convention():
             "X-Request-Published": published_time,
         },
     })))
+    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["MessageAttributes"]), is_(equal_to("ADFASDF"))
+    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["MessageAttributes"], is_(equal_to({
+        "media_type": {
+            "DataType": "String",
+            "StringValue": "application/vnd.globality.pubsub._.created.foo"
+        },
+    })))
 
 
 def test_publish_by_identity_convention():
@@ -172,6 +179,12 @@ def test_publish_by_identity_convention():
         "id": "1",
         "opaqueData": {
             "X-Request-Published": str(published_time),
+        },
+    })))
+    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["MessageAttributes"], is_(equal_to({
+        "media_type": {
+            "DataType": "String",
+            "StringValue": "application/vnd.globality.pubsub._.deleted.foo"
         },
     })))
 

--- a/microcosm_pubsub/tests/conventions/test_messages.py
+++ b/microcosm_pubsub/tests/conventions/test_messages.py
@@ -144,7 +144,6 @@ def test_publish_by_uri_convention():
             "X-Request-Published": published_time,
         },
     })))
-    assert_that(graph.sns_producer.sns_client.publish.call_args[1]["MessageAttributes"]), is_(equal_to("ADFASDF"))
     assert_that(graph.sns_producer.sns_client.publish.call_args[1]["MessageAttributes"], is_(equal_to({
         "media_type": {
             "DataType": "String",

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -67,11 +67,12 @@ def test_raw_consume():
     """
     graph = ExampleDaemon.create_for_testing().graph
     # simulate the response structure
-    graph.sqs_consumer.sqs_client.receive_message.return_value = dict(Messages=[dict(
-        MessageId=MESSAGE_ID,
-        ReceiptHandle=RECEIPT_HANDLE,
-        MD5OfBody="7efaa8404863d47c51ed0e20b9014aec",
-        Body=dumps(dict(
+    graph.sqs_consumer.sqs_client.receive_message.return_value = dict(Messages=[
+        dict(
+            MessageId=MESSAGE_ID,
+            ReceiptHandle=RECEIPT_HANDLE,
+            MD5OfBody="7efaa8404863d47c51ed0e20b9014aec",
+            Body=dumps(dict(
                 data="data",
                 mediaType=DerivedSchema.MEDIA_TYPE,
             )),

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -58,3 +58,44 @@ def test_consume():
         data="data",
         media_type=DerivedSchema.MEDIA_TYPE,
     ))))
+
+
+def test_raw_consume():
+    """
+    Test that messages sent via raw message delivery can be handled
+
+    """
+    graph = ExampleDaemon.create_for_testing().graph
+    # simulate the response structure
+    graph.sqs_consumer.sqs_client.receive_message.return_value = dict(Messages=[dict(
+        MessageId=MESSAGE_ID,
+        ReceiptHandle=RECEIPT_HANDLE,
+        MD5OfBody="7efaa8404863d47c51ed0e20b9014aec",
+        Body=dumps(dict(
+                data="data",
+                mediaType=DerivedSchema.MEDIA_TYPE,
+            )),
+        ),
+    ])
+
+    messages = graph.sqs_consumer.consume()
+
+    # SQS should have been called
+    graph.sqs_consumer.sqs_client.receive_message.assert_called_with(
+        AttributeNames=[
+            "ApproximateReceiveCount",
+        ],
+        QueueUrl="queue",
+        MaxNumberOfMessages=10,
+        WaitTimeSeconds=1,
+    )
+
+    # and response translated properly
+    assert_that(messages, has_length(1))
+    assert_that(messages[0].consumer, is_(equal_to(graph.sqs_consumer)))
+    assert_that(messages[0].message_id, is_(equal_to(MESSAGE_ID)))
+    assert_that(messages[0].receipt_handle, is_(equal_to(RECEIPT_HANDLE)))
+    assert_that(messages[0].content, is_(equal_to(dict(
+        data="data",
+        media_type=DerivedSchema.MEDIA_TYPE,
+    ))))


### PR DESCRIPTION
Up until now, we've basically supported a simple model wherein every
daemon is notified about every event, with message filtering being done
at the consumer level. This is a tad wasteful and increases message
delivery time.

SNS supports the ability add subscription-level filters, such that they
only receive a subset of messages based on the attached metadata.

To support message filtering in our services / daemons, we need to be
able to:
* Attach message attributes to published messages
* Parse message sent via raw message delivery

For these purposes, I've initially chosen a simple media type-based
filtering. While SNS supports more complex conditions, this should be
sufficient for now.

The SNS/SQS documentation implies that raw message parsing is needed to
be able to support message filtering. While that claim is a tad dubious
(I was able to accomplish filtering without it), adding support
shouldn't hurt.

Note that this isn't quite yet ready; there is some more validation I want to do first.