### PR TITLE
Release/glob 33011 changed messages (#168)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.25.0
+current_version = 1.26.0
 commit = False
 tag = False
 

--- a/microcosm_pubsub/conventions/messages.py
+++ b/microcosm_pubsub/conventions/messages.py
@@ -24,6 +24,19 @@ class URIMessageSchema(PubSubMessageSchema):
         return self.MEDIA_TYPE
 
 
+class ChangedURIMessageSchema(URIMessageSchema):
+    """
+    Define a baseline message schema that points to the URI of a updated resource, with the updated value.
+
+    By convention, pubsub messages are a reference to something which happened, but changed messages can
+    be published (and handled) before the changes are comitted to DB. Keeping the changed field on the message
+    allows us to retry handling the message in case value doesn't match the one in the message.
+
+    """
+    field_name = fields.String()
+    new_value = fields.String()
+
+
 class IdentityMessageSchema(PubSubMessageSchema):
     """
     Define a baseline message schema that points to (the identity of) a resource that experienced a lifecycle change.

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -9,7 +9,11 @@ from microcosm.api import defaults
 from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.codecs import PubSubMessageCodec
-from microcosm_pubsub.conventions.messages import IdentityMessageSchema, URIMessageSchema
+from microcosm_pubsub.conventions.messages import (
+    ChangedURIMessageSchema,
+    IdentityMessageSchema,
+    URIMessageSchema,
+)
 
 
 class AlreadyRegisteredError(Exception):
@@ -75,6 +79,8 @@ class PubSubMessageSchemaRegistry:
             # use convention otherwise
             if self.lifecycle_change.Deleted in media_type.split("."):
                 schema = IdentityMessageSchema(media_type)
+            elif self.lifecycle_change.Changed in media_type.split("."):
+                schema = ChangedURIMessageSchema(media_type)
             else:
                 schema = URIMessageSchema(media_type)
 

--- a/microcosm_pubsub/tests/test_registry.py
+++ b/microcosm_pubsub/tests/test_registry.py
@@ -13,6 +13,8 @@ from hamcrest import (
 from microcosm.api import binding, create_object_graph
 
 from microcosm_pubsub.codecs import DEFAULT_MEDIA_TYPE, PubSubMessageCodec, PubSubMessageSchema
+from microcosm_pubsub.conventions import changed
+from microcosm_pubsub.conventions.messages import ChangedURIMessageSchema
 from microcosm_pubsub.registry import AlreadyRegisteredError
 from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon, noop_handler
 
@@ -36,6 +38,10 @@ def configure_another_handler(graph):
 
 class AnotherSchema(PubSubMessageSchema):
     MEDIA_TYPE = "application/vnd.microcosm.another"
+
+
+class ChangedSchema(PubSubMessageSchema):
+    MEDIA_TYPE = changed("Foo")
 
 
 class TestDerivedPubSubMessageCodecRegistry:
@@ -79,6 +85,11 @@ class TestDerivedPubSubMessageCodecRegistry:
         schema = self.registry.find(DerivedSchema.MEDIA_TYPE)
         assert_that(schema, is_(instance_of(PubSubMessageCodec)))
         assert_that(schema.schema, is_(instance_of(DerivedSchema)))
+
+    def test_find_changed(self):
+        schema = self.registry.find(ChangedSchema.MEDIA_TYPE)
+        assert_that(schema, is_(instance_of(PubSubMessageCodec)))
+        assert_that(schema.schema, is_(instance_of(ChangedURIMessageSchema)))
 
 
 class TestDerivedSQSMessageHandlerRegistry:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "1.25.0"
+version = "1.26.0"
 
 setup(
     name=project,


### PR DESCRIPTION
* GLOB-33011 - changed schema has two new fields. handler checks them (#167)

Why?
When publishing a changed(Class) handler could not determine if it caught the message
before the change was committed to the DB. To resolve this, we're adding
a new default message for changed events. message has `field_name` and `new_value`
on it. Handler checks that the retrieved object has the correct value, and in
case it isn't, nacks and retries later.

What I've done:
1. added a new `ChangedMessageSchema` type with `field_name` and `new_value`
2. that type is the default for changed events
3. amended `URIHandler` to check the new value and nack if doesn't fit the message

* bump version to 1.26.0