### PR TITLE
Log publish messages as debug.

### DIFF
--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -62,7 +62,7 @@ class SQSMessageDispatcher:
                 message_batch_size=message_batch_size,
                 batch_elapsed_time=batch_elapsed_time,
             )
-            self.logger.info(message)
+            self.logger.debug(message)
 
         self.send_batch_metrics(batch_elapsed_time, message_batch_size)
 

--- a/microcosm_pubsub/producer.py
+++ b/microcosm_pubsub/producer.py
@@ -106,7 +106,7 @@ class SNSProducer:
                 MessageAttributes=pubsub_message.message_attributes,
             )
 
-        self.logger.info("Published message with media type {media_type}", extra=extra)
+        self.logger.debug("Published message with media type {media_type}", extra=extra)
 
         return result["MessageId"]
 


### PR DESCRIPTION
In terms of numbers of logs, these logs make up about 6% of our logs in
the last day and yet they provide minimal value.