### PR TITLE
Syntactic sugar to give names to function argument and result

### DIFF
--- a/microcosm_pubsub/chain/__init__.py
+++ b/microcosm_pubsub/chain/__init__.py
@@ -4,6 +4,7 @@ from microcosm_pubsub.chain.statements import (  # noqa: F401
     assign,
     assign_constant,
     assign_function,
+    call,
     extract,
     for_each,
     switch,

--- a/microcosm_pubsub/chain/statements/__init__.py
+++ b/microcosm_pubsub/chain/statements/__init__.py
@@ -4,6 +4,7 @@ from microcosm_pubsub.chain.statements.assign import (  # noqa: F401
     assign_function,
     extract,
 )
+from microcosm_pubsub.chain.statements.call import call  # noqa: F401
 from microcosm_pubsub.chain.statements.for_each import for_each  # noqa: F401
 from microcosm_pubsub.chain.statements.switch import switch  # noqa: F401
 from microcosm_pubsub.chain.statements.try_chain import try_chain  # noqa: F401

--- a/microcosm_pubsub/chain/statements/assign.py
+++ b/microcosm_pubsub/chain/statements/assign.py
@@ -1,5 +1,6 @@
 """
 assign("foo.bar").to("baz")
+assign_constant(1).to("qux")
 
 """
 from inspect import getfullargspec
@@ -36,7 +37,6 @@ class Constant:
 
 
 class Function:
-
     def __init__(self, func):
         self.func = func
         try:
@@ -99,7 +99,7 @@ def assign_function(this):
 
 def extract(name, key, key_property=None):
     """
-    Extract an argument from a context to anotherwise context key
+    Extract an argument from a context to another context key
 
     :param name: new context key
     :param key: old context key

--- a/microcosm_pubsub/chain/statements/call.py
+++ b/microcosm_pubsub/chain/statements/call.py
@@ -1,0 +1,51 @@
+"""
+Syntactic sugar using existing primitives defined
+
+"""
+from microcosm_pubsub.chain import Chain
+from microcosm_pubsub.chain.context import ScopedSafeContext
+
+
+class LocalCallWrapper:
+    """
+    Syntactic sugar making it easy to call the same function multiple times in a chain
+    Usage:
+    Chain(
+       ...,
+       call(a_function).with_args(a_function_arg="an_existing_context_key").as_("name_of_the_result_in_context"),
+       call(a_function).with_args(a_function_arg="some_other_key").as_("another_name"),
+    )
+
+    """
+    def __init__(self, func):
+        self.func = func
+        self.chain = Chain(func)
+        self.kwargs_mapping = dict()
+        self.result_name = None
+        self.local_context = None
+
+    def with_args(self, **kwargs):
+        self.kwargs_mapping = kwargs
+        return self
+
+    def as_(self, name):
+        self.result_name = name
+        return self
+
+    def _build_local_kwargs(self, parent_context):
+        return {
+            local_name: parent_context[parent_name]
+            for local_name, parent_name
+            in self.kwargs_mapping.items()
+        }
+
+    def __call__(self, context):
+        local_kwargs = self._build_local_kwargs(context)
+        self.local_context = ScopedSafeContext(context, **local_kwargs)
+        result = self.chain(self.local_context)
+        context[self.result_name] = result
+        return result
+
+
+def call(func):
+    return LocalCallWrapper(func)

--- a/microcosm_pubsub/chain/statements/call.py
+++ b/microcosm_pubsub/chain/statements/call.py
@@ -37,7 +37,7 @@ class LocalCallWrapper:
 
         for local_name, mapped_value in self.kwargs.items():
             if local_name in parent_context:
-                raise ValueError(f"Argument `{local_name}` for local overshadows existing context key")
+                raise ValueError(f"Argument `{local_name}` for local call overshadows existing context key")
 
             if isinstance(mapped_value, str) and mapped_value in parent_context:
                 # mapped value points to parent context

--- a/microcosm_pubsub/chain/statements/call.py
+++ b/microcosm_pubsub/chain/statements/call.py
@@ -33,6 +33,9 @@ class LocalCallWrapper:
         return self
 
     def _build_local_kwargs(self, parent_context):
+        for local_name in self.kwargs_mapping:
+            if local_name in parent_context:
+                raise ValueError(f"Argument `{local_name}` for local overshadows existing context key")
         return {
             local_name: parent_context[parent_name]
             for local_name, parent_name

--- a/microcosm_pubsub/chain/statements/call.py
+++ b/microcosm_pubsub/chain/statements/call.py
@@ -20,12 +20,12 @@ class LocalCallWrapper:
     def __init__(self, func):
         self.func = func
         self.chain = Chain(func)
-        self.kwargs_mapping = dict()
+        self.kwargs = dict()
         self.result_name = None
         self.local_context = None
 
     def with_args(self, **kwargs):
-        self.kwargs_mapping = kwargs
+        self.kwargs = kwargs
         return self
 
     def as_(self, name):
@@ -33,14 +33,20 @@ class LocalCallWrapper:
         return self
 
     def _build_local_kwargs(self, parent_context):
-        for local_name in self.kwargs_mapping:
+        local_kwargs = dict()
+
+        for local_name, mapped_value in self.kwargs.items():
             if local_name in parent_context:
                 raise ValueError(f"Argument `{local_name}` for local overshadows existing context key")
-        return {
-            local_name: parent_context[parent_name]
-            for local_name, parent_name
-            in self.kwargs_mapping.items()
-        }
+
+            if isinstance(mapped_value, str) and mapped_value in parent_context:
+                # mapped value points to parent context
+                local_kwargs[local_name] = parent_context[mapped_value]
+            else:
+                # mapped value is a constant
+                local_kwargs[local_name] = mapped_value
+
+        return local_kwargs
 
     def __call__(self, context):
         local_kwargs = self._build_local_kwargs(context)

--- a/microcosm_pubsub/matchers/message.py
+++ b/microcosm_pubsub/matchers/message.py
@@ -88,7 +88,7 @@ class PublishedMessageMatcher(IsObjectWithProperty):
     """
     A matcher that validates a single published message property.
 
-    This matcher is primarily a cosmetric change describe errors in terms of messages
+    This matcher is primarily a cosmetic change describe errors in terms of messages
     (and not generic objects).
 
     """

--- a/microcosm_pubsub/tests/chain/statements/test_call.py
+++ b/microcosm_pubsub/tests/chain/statements/test_call.py
@@ -1,23 +1,59 @@
-from hamcrest import assert_that, equal_to
+from hamcrest import (
+    assert_that,
+    calling,
+    equal_to,
+    raises,
+)
 
 from microcosm_pubsub.chain import Chain
 from microcosm_pubsub.chain.statements.call import call
 
 
-def test_local_call_wrapper():
-    def double_it(input):
-        return 2 * input
+class TestLocalCallWrapper:
+    def two_calls_of_same_function(self):
+        def double_it(input):
+            return 2 * input
 
-    def multiply(double_one, double_three):
-        return double_one * double_three
+        def multiply(double_one, double_three):
+            return double_one * double_three
 
-    chain = Chain(
-        call(double_it).with_args(input="one").as_("double_one"),
-        call(double_it).with_args(input="three").as_("double_three"),
-        multiply,
-    )
+        chain = Chain(
+            call(double_it).with_args(input="one").as_("double_one"),
+            call(double_it).with_args(input="three").as_("double_three"),
+            multiply,
+        )
 
-    assert_that(
-        chain(one=1, three=3),
-        equal_to(12),
-    )
+        assert_that(
+            chain(one=1, three=3),
+            equal_to(12),
+        )
+
+    def mix_parent_child_context(self):
+        # `sum_base` will come from the parent context
+        # `addend` will be defined using `call`
+        def sum(sum_base, addend):
+            return sum_base + addend
+
+        def noop(twelve):
+            return twelve
+
+        chain = Chain(
+            call(sum).with_args(addend="two").as_("twelve"),
+            noop,
+        )
+
+        assert_that(
+            chain(sum_base=10, two=2),
+            equal_to(12),
+        )
+
+    def error_on_overwrite_parent_context(self):
+        # the kwargs in `with_args` overshadows an existing key on the context
+        chain = Chain(
+            call(sum).with_args(input="another_word").as_("twelve"),
+        )
+
+        assert_that(
+            calling(chain).with_args(input="hello", another_word="world"),
+            raises(ValueError),
+        )

--- a/microcosm_pubsub/tests/chain/statements/test_call.py
+++ b/microcosm_pubsub/tests/chain/statements/test_call.py
@@ -1,0 +1,23 @@
+from hamcrest import assert_that, equal_to
+
+from microcosm_pubsub.chain import Chain
+from microcosm_pubsub.chain.statements.call import call
+
+
+def test_local_call_wrapper():
+    def double_it(input):
+        return 2 * input
+
+    def multiply(double_one, double_three):
+        return double_one * double_three
+
+    chain = Chain(
+        call(double_it).with_args(input="one").as_("double_one"),
+        call(double_it).with_args(input="three").as_("double_three"),
+        multiply,
+    )
+
+    assert_that(
+        chain(one=1, three=3),
+        equal_to(12),
+    )

--- a/microcosm_pubsub/tests/chain/statements/test_call.py
+++ b/microcosm_pubsub/tests/chain/statements/test_call.py
@@ -10,7 +10,7 @@ from microcosm_pubsub.chain.statements.call import call
 
 
 class TestLocalCallWrapper:
-    def two_calls_of_same_function(self):
+    def test_two_calls_of_same_function(self):
         def double_it(input):
             return 2 * input
 
@@ -28,9 +28,7 @@ class TestLocalCallWrapper:
             equal_to(12),
         )
 
-    def mix_parent_child_context(self):
-        # `sum_base` will come from the parent context
-        # `addend` will be defined using `call`
+    def test_call_with_constant(self):
         def sum(sum_base, addend):
             return sum_base + addend
 
@@ -38,8 +36,36 @@ class TestLocalCallWrapper:
             return twelve
 
         chain = Chain(
-            call(sum).with_args(addend="two").as_("twelve"),
+            call(sum).with_args(addend=2).as_("twelve"),
             noop,
+        )
+
+        assert_that(
+            chain(sum_base=10),
+            equal_to(12),
+        )
+
+    def test_call_with_string_constant(self):
+        def concatenate(word, suffix):
+            return f"{word}{suffix}"
+
+        chain = Chain(
+            call(concatenate).with_args(suffix="er").as_("more_word"),
+        )
+
+        assert_that(
+            chain(word="high"),
+            equal_to("higher"),
+        )
+
+    def test_mix_parent_child_context(self):
+        # `sum_base` will come from the parent context
+        # `addend` will be defined using `call`
+        def sum(sum_base, addend):
+            return sum_base + addend
+
+        chain = Chain(
+            call(sum).with_args(addend="two").as_("twelve"),
         )
 
         assert_that(
@@ -47,7 +73,7 @@ class TestLocalCallWrapper:
             equal_to(12),
         )
 
-    def error_on_overwrite_parent_context(self):
+    def test_error_on_overwrite_parent_context(self):
         # the kwargs in `with_args` overshadows an existing key on the context
         chain = Chain(
             call(sum).with_args(input="another_word").as_("twelve"),


### PR DESCRIPTION
We don't have an easy, explicity way to temporarily change the context for a single function call.
This limits the amount of code reuse we can do: currently we'd need to write two functions with different argument names, calling the same underlying logic.
This new syntax allows us to do that much more easily.