### PR TITLE
Resource Caching Improvements

### DIFF
--- a/microcosm_pubsub/caching/memcached.py
+++ b/microcosm_pubsub/caching/memcached.py
@@ -72,12 +72,16 @@ class MemcachedCache(CacheBase):
         self,
         host="localhost",
         port=11211,
+        connect_timeout=None,
+        read_timeout=None,
         serializer=json_serializer,
         deserializer=json_deserializer,
         testing=False,
     ):
         client_kwargs = dict(
             server=(host, port),
+            connect_timeout=connect_timeout,
+            timeout=read_timeout,
             serializer=json_serializer,
             deserializer=json_deserializer,
         )

--- a/microcosm_pubsub/caching/resource_cache.py
+++ b/microcosm_pubsub/caching/resource_cache.py
@@ -8,6 +8,8 @@ from microcosm_pubsub.caching.memcached import MemcachedCache
     enabled=typed(boolean, default_value=False),
     host="localhost",
     port=typed(int, default_value=11211),
+    connect_timeout=3,
+    read_timeout=2,
 )
 def configure_resource_cache(graph):
     """
@@ -21,6 +23,8 @@ def configure_resource_cache(graph):
     kwargs = dict(
         host=graph.config.resource_cache.host,
         port=graph.config.resource_cache.port,
+        connect_timeout=graph.config.resource_cache.connect_timeout,
+        read_timeout=graph.config.resource_cache.read_timeout,
     )
     if graph.metadata.testing:
         kwargs.update(dict(testing=True))

--- a/microcosm_pubsub/tests/handlers/test_uri_handler.py
+++ b/microcosm_pubsub/tests/handlers/test_uri_handler.py
@@ -158,9 +158,12 @@ class TestURIHandler:
         )
         graph.lock()
 
-        uri = "http://localhost"
+        # Nb. changed events should not be whitelisted for caching
+        uri = "https://service.env.globality.io/api/v2/project_event/0598355c-5b19-49bd-a755-146204220a5b"
+        media_type = "application/vnd.globality.pubsub._.changed.project_event.project_brief_submitted"
         message = dict(
             uri=uri,
+            mediaType=media_type,
         )
         json_data = dict(foo="bar", bar="baz")
 
@@ -200,8 +203,10 @@ class TestURIHandler:
         graph.lock()
 
         uri = "https://service.env.globality.io/api/v2/project_event/0598355c-5b19-49bd-a755-146204220a5b"
+        media_type = "application/vnd.globality.pubsub._.created.project_event.project_brief_submitted"
         message = dict(
             uri=uri,
+            mediaType=media_type,
         )
         json_data = dict(foo="bar", bar="baz")
 
@@ -247,8 +252,10 @@ class TestURIHandler:
         graph.lock()
 
         uri = "https://service.env.globality.io/api/v2/project_event/0598355c-5b19-49bd-a755-146204220a5b"
+        media_type = "application/vnd.globality.pubsub._.created.project_event.project_brief_submitted"
         message = dict(
             uri=uri,
+            mediaType=media_type,
         )
         json_data = dict(foo="bar", bar="baz")
 


### PR DESCRIPTION
Building on the previous PR #177 this PR adds a couple of additional enhancements:

* Connect and Read timeout settings for memcache client to avoid hangups on network issues
* Include media-type of pubsub message as part of context for resource whitelisting callable. This in particular is used to make sure we do not try to use the cache to get or set from the cache for pubsub messages which are not strictly 'Create' ones. This avoids any issues to do with the fact that some Event resources currently are mutable (in particular FactEvent and ChatroomEvent, for purposes of re-encryption and redaction)