### PR TITLE
Rework de/serialization for pubsub messages

### DIFF
--- a/microcosm_pubsub/batch.py
+++ b/microcosm_pubsub/batch.py
@@ -27,6 +27,3 @@ class MessageBatchSchema(PubSubMessageSchema):
     MEDIA_TYPE = created("batch_message")
 
     messages = fields.List(fields.Nested(BatchedMessageSchema), required=True)
-
-    def deserialize_media_type(self, obj):
-        return MessageBatchSchema.MEDIA_TYPE

--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -3,6 +3,7 @@ Message encoding and decoding.
 
 """
 from json import dumps, loads
+from typing import Any, Dict, Optional
 
 from marshmallow import (
     EXCLUDE,
@@ -39,38 +40,16 @@ class PubSubMessageSchema(Schema):
     Base schema for messages, including a media type.
 
     """
-    media_type = fields.Method(
-        # called by dump
-        serialize="serialize_media_type",
-        # called by load
-        deserialize="deserialize_media_type",
-        attribute="mediaType",
-        # need to set missing to non-None or marshmallow won't call the deserialize function
-        missing=DEFAULT_MEDIA_TYPE,
-    )
-    opaque_data = fields.Dict(
-        attribute="opaqueData",
+    MEDIA_TYPE = DEFAULT_MEDIA_TYPE
+
+    mediaType = fields.String(
+        attribute="media_type",
         required=False,
     )
-
-    def serialize_media_type(self, message):
-        """
-        Fetch the media type from the message.
-
-        """
-        try:
-            return message["mediaType"]
-        except KeyError:
-            raise ValidationError("Message did not define a media type")
-
-    def deserialize_media_type(self, obj):
-        """
-        Return a custom media type.
-
-        Should be overridden in subclasses.
-
-        """
-        return DEFAULT_MEDIA_TYPE
+    opaqueData = fields.Dict(
+        attribute="opaque_data",
+        required=False,
+    )
 
 
 class MediaTypeSchema(Schema):
@@ -87,10 +66,10 @@ class PubSubMessageCodec:
 
     """
 
-    def __init__(self, schema):
+    def __init__(self, schema: PubSubMessageSchema):
         self.schema = schema
 
-    def encode(self, dct=None, **kwargs):
+    def encode(self, dct: Optional[Dict[str, Any]] = None, **kwargs) -> str:
         """
         Encode a message.
 
@@ -99,10 +78,16 @@ class PubSubMessageCodec:
         """
         message = dct.copy() if dct else dict()
         message.update(kwargs)
-        # We allow unknown fields to pass through (but not included here)
-        # to accommodate unconditional parameter passing during produce()
-        # e.g. passing in `uri` for IdentityMessages
-        return dumps(self.schema.load(message, unknown=EXCLUDE))
+
+        dumped = self.schema.dump(message)
+
+        # NB: Schema dump doesn't run validation
+        errors = self.schema.validate(dumped)
+        if errors:
+            raise ValidationError(message=errors)
+
+        # Dump to string
+        return dumps(dumped)
 
     def decode(self, message):
         """
@@ -119,9 +104,7 @@ class PubSubMessageCodec:
         try:
             # load performs a validation and raises on error
             # Similarly, we exclude unknown fields to avoid errors on decode
-            self.schema.load(dct, unknown=EXCLUDE)
+            return self.schema.load(dct, unknown=EXCLUDE)
         except ValidationError as error:
             # Add more useful information to logs for debugging validation errors.
             raise enrich(error, self.schema)
-
-        return self.schema.dump(dct)

--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -44,7 +44,7 @@ class PubSubMessageSchema(Schema):
 
     mediaType = fields.String(
         attribute="media_type",
-        required=False,
+        required=True,
     )
     opaqueData = fields.Dict(
         attribute="opaque_data",

--- a/microcosm_pubsub/conventions/messages.py
+++ b/microcosm_pubsub/conventions/messages.py
@@ -20,16 +20,13 @@ class URIMessageSchema(PubSubMessageSchema):
 
     uri = fields.String(required=True)
 
-    def deserialize_media_type(self, obj):
-        return self.MEDIA_TYPE
-
 
 class ChangedURIMessageSchema(URIMessageSchema):
     """
     Define a baseline message schema that points to the URI of a updated resource, with the updated value.
 
     By convention, pubsub messages are a reference to something which happened, but changed messages can
-    be published (and handled) before the changes are comitted to DB. Keeping the changed field on the message
+    be published (and handled) before the changes are committed to DB. Keeping the changed field on the message
     allows us to retry handling the message in case value doesn't match the one in the message.
 
     """
@@ -50,6 +47,3 @@ class IdentityMessageSchema(PubSubMessageSchema):
         self.MEDIA_TYPE = media_type
 
     id = fields.String(required=True)
-
-    def deserialize_media_type(self, obj):
-        return self.MEDIA_TYPE

--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -33,7 +33,7 @@ def resource_cache_whitelist_callable(media_type, uri):
     ))
 
 
-class URIHandler:
+class URIHandler(metaclass=ABCMeta):
     """
     Base handler for URI-driven events.
 
@@ -53,8 +53,6 @@ class URIHandler:
     log per message processed (unless an error/nack is raised).
 
     """
-    __metaclass__ = ABCMeta
-
     def __init__(
         self,
         graph,

--- a/microcosm_pubsub/matchers/message.py
+++ b/microcosm_pubsub/matchers/message.py
@@ -76,7 +76,7 @@ class PublishedMessage:
         Iterate over published messages from a mocked SNSProducer.
 
         """
-        if isinstance(sns_producer, Mock):
+        if isinstance(sns_producer, Mock):  # type: ignore
             target = sns_producer.produce
         else:
             target = sns_producer.sns_client.publish

--- a/microcosm_pubsub/tests/fixtures.py
+++ b/microcosm_pubsub/tests/fixtures.py
@@ -22,9 +22,6 @@ class DerivedSchema(PubSubMessageSchema):
 
     data = fields.String(required=True)
 
-    def deserialize_media_type(self, obj):
-        return DerivedSchema.MEDIA_TYPE
-
 
 @schema
 class DuckTypeSchema(Schema):


### PR DESCRIPTION
The current method used for de/serializing messages is a bit obtuse at
the moment, and prevents some amount of ability to use some enhanced
messages (e.g. enums).

Note that this change may not backwards compatible, producing services
may start creating messages that will fail decoding. Edit: From the looks of it, this is in line with what's already being published in the message today (i.e. camelCased fields). This is just a possible warning here.