### PR TITLE
Use dictionary syntax instead of constructor

### DIFF
--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -146,7 +146,7 @@ class MessageHandlingResult:
             self.result.level,
             entry,
             exc_info=self.exc_info,
-            extra=dict(**self.extra, **opaque.as_dict()),
+            extra={**opaque.as_dict(), **self.extra},
         )
 
     def resolve(self, message):

--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -193,3 +193,23 @@ class TestMessageHandlingResult:
             ReceiptHandle=RECEIPT_HANDLE,
             VisibilityTimeout=5,
         )
+
+    def test_log_merge_keys(self):
+        def handler(message):
+            return True
+
+        result = MessageHandlingResult.invoke(
+            handler=handler,
+            message=self.message,
+        ).resolve(self.message)
+
+        result.extra = dict(
+            foo="bar"
+        )
+        self.graph.opaque["foo"] = "baz"
+
+        # This doesn't error
+        result.log(
+            self.graph.logger,
+            self.graph.opaque
+        )


### PR DESCRIPTION
The constructor syntax `dict(**a, **b)` will error if `a` and `b` share keys, where the `{}` syntax will simply take the value from the second item.