### PR TITLE
Remove media type for convention-driven message schema

### DIFF
--- a/microcosm_pubsub/conventions/messages.py
+++ b/microcosm_pubsub/conventions/messages.py
@@ -14,10 +14,6 @@ class URIMessageSchema(PubSubMessageSchema):
     the consumer can retry a few times before giving up (e.g. via SQS dead-lettering).
 
     """
-    def __init__(self, media_type, **kwargs):
-        super().__init__(**kwargs)
-        self.MEDIA_TYPE = media_type
-
     uri = fields.String(required=True)
 
 
@@ -42,8 +38,4 @@ class IdentityMessageSchema(PubSubMessageSchema):
     a URI may not be available.
 
     """
-    def __init__(self, media_type, **kwargs):
-        super().__init__(**kwargs)
-        self.MEDIA_TYPE = media_type
-
     id = fields.String(required=True)

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -77,11 +77,11 @@ class PubSubMessageSchemaRegistry:
         except KeyError:
             # use convention otherwise
             if self.lifecycle_change.Deleted in media_type.split("."):
-                schema = IdentityMessageSchema(media_type)
+                schema = IdentityMessageSchema()
             elif self.lifecycle_change.Changed in media_type.split("."):
-                schema = ChangedURIMessageSchema(media_type)
+                schema = ChangedURIMessageSchema()
             else:
-                schema = URIMessageSchema(media_type)
+                schema = URIMessageSchema()
 
         return PubSubMessageCodec(schema)
 

--- a/microcosm_pubsub/tests/conventions/test_messages.py
+++ b/microcosm_pubsub/tests/conventions/test_messages.py
@@ -19,11 +19,9 @@ from microcosm.api import create_object_graph
 from microcosm_pubsub.codecs import PubSubMessageCodec
 from microcosm_pubsub.conventions import (
     IdentityMessageSchema,
-    LifecycleChange,
     URIMessageSchema,
     created,
     deleted,
-    make_media_type,
 )
 from microcosm_pubsub.decorators import schema
 from microcosm_pubsub.tests.fixtures import ExampleDaemon, noop_handler
@@ -84,19 +82,13 @@ class CustomMessageSchema(URIMessageSchema):
     MEDIA_TYPE = created("Resource")
     enumField = EnumField(TestEnum, attribute="enum_field", required=True)
 
-    def __init__(self, **kwargs):
-        super().__init__(
-            media_type=CustomMessageSchema.MEDIA_TYPE,
-            **kwargs,
-        )
-
 
 def test_encode_uri_message_schema():
     """
     Message encoding should include the standard URIMessage fields.
 
     """
-    schema = URIMessageSchema(make_media_type("Foo", lifecycle_change=LifecycleChange.Deleted))
+    schema = URIMessageSchema()
     codec = PubSubMessageCodec(schema)
     assert_that(
         loads(codec.encode(
@@ -145,7 +137,7 @@ def test_encode_identity_message_schema():
     Message encoding should include the standard IdentityMessage fields.
 
     """
-    schema = IdentityMessageSchema(make_media_type("Foo", lifecycle_change=LifecycleChange.Deleted))
+    schema = IdentityMessageSchema()
     codec = PubSubMessageCodec(schema)
     assert_that(
         loads(codec.encode(
@@ -168,7 +160,7 @@ def test_decode_uri_message_schema():
     Message decoding should process standard URIMessage fields.
 
     """
-    schema = URIMessageSchema(make_media_type("Foo"))
+    schema = URIMessageSchema()
     codec = PubSubMessageCodec(schema)
     message = dumps({
         "mediaType": "application/vnd.globality.pubsub.foo",
@@ -189,7 +181,7 @@ def test_decode_identity_message_schema():
     Message decoding should process standard IdentityMessage fields.
 
     """
-    identity_schema = IdentityMessageSchema(make_media_type("Foo"))
+    identity_schema = IdentityMessageSchema()
     codec = PubSubMessageCodec(identity_schema)
     message = dumps({
         "mediaType": "application/vnd.globality.pubsub._.created.foo",


### PR DESCRIPTION
**Why?**
A media type was being passed in to our convention-driven message schemas. This was a hacky way of making them work with the pubsub registry; this has since been fixed by allowing the registry to store media types without an associated schema, in which case it defaults back to convention.

Having a required constructor argument for a schema is bad practice in my opinion, especially since that argument is not actually needed to define the schema.

**What?**
Remove `media_type` from constructor for `URIMessageSchema` and `IdentityMessageSchema`.