### PR TITLE
Add extra info to debug logs to ease local debugging

### DIFF
--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -2,7 +2,7 @@
 Test result handling.
 
 """
-from hamcrest import assert_that, has_entries, has_properties
+from hamcrest import assert_that, has_entries, has_properties, is_, equal_to
 from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.errors import (
@@ -212,4 +212,12 @@ class TestMessageHandlingResult:
         result.log(
             self.graph.logger,
             self.graph.opaque
+        )
+
+    def test_log_message(self):
+        assert_that(
+            str(MessageHandlingResult(
+                media_type="MEDIA", result=MessageHandlingResultType.SKIPPED,
+                exc_reason="Skippity skip")),
+            is_(equal_to("Result for media type: MEDIA was: SKIPPED reason: Skippity skip"))
         )

--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -2,7 +2,7 @@
 Test result handling.
 
 """
-from hamcrest import assert_that, has_entries, has_properties, is_, equal_to
+from hamcrest import assert_that, equal_to, has_entries, has_properties, is_
 from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.errors import (


### PR DESCRIPTION
**Before**
```
09:49 $  daemon-main --debug --sqs-queue-url message.json --envelope NaiveSQSEnvelope
2019-11-29 09:49:58,743 - service - [INFO] - Starting daemon 
2019-11-29 09:49:58,743 - service - [INFO] - Handling: some-media-type with handler: Handler
2019-11-29 09:49:59,355 - Handler - [INFO] - Result for media type: some-media-type was : SKIPPED
```

**After**
```
09:49 $  daemon-main --debug --sqs-queue-url message.json --envelope NaiveSQSEnvelope
2019-11-29 09:49:58,743 - service - [INFO] - Starting daemon 
2019-11-29 09:49:58,743 - service - [INFO] - Handling: some-media-type with handler: Handler
2019-11-29 09:49:59,355 - Handler - [INFO] - Result for media type: some-media-type was: SKIPPED reason: service doesn't like your message
```