### PR TITLE
Improve error message handling during chain handler execution (#201)

### DIFF
--- a/microcosm_pubsub/chain/chain.py
+++ b/microcosm_pubsub/chain/chain.py
@@ -63,6 +63,8 @@ class Chain:
         context = context or self.new_context_type()
         context.update(kwargs)
 
+        res = None
+
         for link in self.links:
             func = self.apply_decorators(context, link)
             res = func()

--- a/microcosm_pubsub/chain/exceptions.py
+++ b/microcosm_pubsub/chain/exceptions.py
@@ -1,0 +1,9 @@
+class AttributeNotFound(Exception):
+    def __init__(self, parent, attribute):
+        super().__init__(f"Failed to find attribute `{attribute}` on `{parent}`")
+
+
+class ContextKeyNotFound(Exception):
+    def __init__(self, key_error: KeyError, func):
+        context_key, *_ = key_error.args
+        super().__init__(f"Failed to find context key `{context_key}` during evaluation of `{func}`")

--- a/microcosm_pubsub/chain/statements/assign.py
+++ b/microcosm_pubsub/chain/statements/assign.py
@@ -5,6 +5,8 @@ assign_constant(1).to("qux")
 """
 from inspect import getfullargspec
 
+from microcosm_pubsub.chain.exceptions import AttributeNotFound
+
 
 class Reference:
 
@@ -22,7 +24,10 @@ class Reference:
             if hasattr(value, part):
                 value = getattr(value, part)
             else:
-                value = value[part]
+                try:
+                    value = value[part]
+                except KeyError:
+                    raise AttributeNotFound(self.parts[0], part)
 
         return value
 

--- a/microcosm_pubsub/tests/chain/statements/test_assign.py
+++ b/microcosm_pubsub/tests/chain/statements/test_assign.py
@@ -1,6 +1,13 @@
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import (
+    assert_that,
+    calling,
+    equal_to,
+    is_,
+    raises,
+)
 
 from microcosm_pubsub.chain import Chain
+from microcosm_pubsub.chain.exceptions import AttributeNotFound
 from microcosm_pubsub.chain.statements import (
     assign,
     assign_constant,
@@ -143,4 +150,14 @@ def test_assign_function_with_builtin():
     assert_that(
         chain(),
         is_(equal_to(dict())),
+    )
+
+
+def test_assign_missing_property():
+    chain = Chain(
+        assign("arg.missing").to("param"),
+    )
+    assert_that(
+        calling(chain).with_args(arg=dict(data=200)),
+        raises(AttributeNotFound, "Failed to find attribute `missing` on `arg`"),
     )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     zip_safe=False,
     python_requires=">=3.6",
     install_requires=[
+        "tornado<6",
         "boto3>=1.5.8",
         "dataclasses;python_version<'3.7'",
         "marshmallow>=3.0.0",


### PR DESCRIPTION
* Improve error message handling during chain handler execution

Reading chain errors tends to be a bit cryptic, mostly due to the fact
that the actual calling function has been funnelled/wrapped so many
times that it may be unclear exactly where an error has arisen.

Example:
```
  File "microcosm_pubsub/handlers/chain_handlers.py", line 42, in handle
    chain(**kwargs)
  File "microcosm_pubsub/chain/chain.py", line 68, in __call__
    res = func()
  File "microcosm_pubsub/chain/context_decorators.py", line 38, in decorate
    for arg_name, default in positional_args[len(args):]
  File "microcosm_pubsub/chain/context_decorators.py", line 39, in <dictcomp>
    if arg_name not in kwargs
  File "microcosm_pubsub/chain/context.py", line 20, in __getitem__
    return self.store[key]
KeyError: 'context_key'
```

Additionally, failures to find an attribute during `assign` calls end up
also missing helpful context:
```
  File "microcosm-pubsub/microcosm_pubsub/chain/statements/assign.py", line 28, in __call__
    value = value[part]
  File "site-packages/bravado_core/model.py", line 435, in __getitem__
    return self.__dict[property_name]
KeyError: 'id'
```

This changeset updates errors such that:
* On the inability to find a context key when evaluating a chained
function, both the key and the function are reported in the error
Example:
```
microcosm_pubsub.chain.exceptions.ContextKeyNotFound: Failed to find context_key `key` during evaluation of `func`
```

* If an attribute is unable to be found during assignment, both the
field and the parent are dutifully reported.
Example:
```
microcosm_pubsub.chain.exceptions.AttributeNotFound: Failed to find attribute `id` on `event`
```