### PR TITLE
Release 2.9.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.8.1
+current_version = 2.9.0
 commit = False
 tag = False
 

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -19,7 +19,8 @@ from microcosm_pubsub.result import MessageHandlingResult, MessageHandlingResult
 @logger
 @defaults(
     # Number of failed attempts after which the message stops being processed
-    message_max_processing_attempts=typed(int, default_value=None)
+    message_max_processing_attempts=typed(int, default_value=None),
+    fetch_uri_resource=typed(bool, default_value=True),
 )
 class SQSMessageDispatcher:
     """

--- a/microcosm_pubsub/handlers/base.py
+++ b/microcosm_pubsub/handlers/base.py
@@ -1,0 +1,155 @@
+"""
+Base pubsub handler
+
+"""
+from abc import ABCMeta
+from re import search
+
+from inflection import titleize
+from microcosm.errors import LockedGraphError, NotBoundError
+
+from microcosm_pubsub.constants import DEFAULT_RESOURCE_CACHE_TTL
+from microcosm_pubsub.conventions.lifecycle import LifecycleChange
+
+
+def resource_cache_whitelist_callable(media_type, uri):
+    """
+    Default resource cache whitelist callable implementation.
+
+    Only whitelists under the following conditions:
+    * verb is created
+    * resource is an event
+
+    """
+    if not media_type:
+        # Nb. likely to happen with mocks and tests.
+        return False
+
+    return all((
+        search(r"/[a-z]+_event/", uri),
+        search(r".{}.".format(LifecycleChange.Created), media_type),
+    ))
+
+
+class PubSubHandler(metaclass=ABCMeta):
+    """
+    Base handler for pubsub messages.
+
+    There are five expected outcomes for this handler:
+      - Raising an error (e.g. a bug)
+      - Skipping the handler.
+      - Handling the message.
+      - Ignoring the message.
+      - Raising a nack to reprocess at a later date (e.g. as a protection against race conditions)
+
+    The middle three cases are all handled here with the expectation that we produce *one* INFO-level
+    log per message processed (unless an error/nack is raised).
+
+    """
+    def __init__(
+        self,
+        graph,
+        retry_nack_timeout=1,
+        resource_nack_timeout=1,
+        resource_cache_enabled=True,
+        resource_cache_ttl=DEFAULT_RESOURCE_CACHE_TTL,
+        resource_cache_whitelist_callable=resource_cache_whitelist_callable,
+    ):
+        self.opaque = graph.opaque
+        self.retry_nack_timeout = retry_nack_timeout
+        self.resource_nack_timeout = resource_nack_timeout
+        self.resource_cache_ttl = resource_cache_ttl
+        self.resource_cache = self.get_resource_cache(graph) if resource_cache_enabled else None
+        self.resource_cache_whitelist_callable = resource_cache_whitelist_callable
+
+    @property
+    def name(self):
+        return titleize(self.__class__.__name__)
+
+    @property
+    def nack_if_not_found(self):
+        return True
+
+    @property
+    def resource_type(self):
+        return dict
+
+    def get_resource_cache(self, graph):
+        try:
+            return graph.resource_cache
+        except (LockedGraphError, NotBoundError):
+            # Nb. if resource cache is globally disabled, will not be bound
+            return None
+
+    def _pre_handle(self, message, uri):
+        self.on_call(message, uri)
+
+        skip_reason = self.get_reason_to_skip(message, uri)
+        if skip_reason is not None:
+            self.on_skip(message, uri, skip_reason)
+            return False
+
+    def __call__(self, message):
+        uri = message["uri"]
+        self._pre_handle(message, uri)
+
+        if self.handle(message, uri):
+            self.on_handle(message, uri)
+            return True
+        else:
+            self.on_ignore(message, uri)
+            return False
+
+    def on_call(self, message, uri):
+        self.logger.debug(
+            "Starting {handler}",
+            extra=dict(
+                handler=self.name,
+                uri=uri,
+            ),
+        )
+
+    def on_skip(self, message, uri, reason):
+        self.logger.info(
+            "Skipping {handler} because {reason}",
+            extra=dict(
+                handler=self.name,
+                reason=reason,
+                uri=uri,
+            ),
+        )
+
+    def on_handle(self, message, uri, **kwargs):
+        self.logger.debug(
+            "Handled {handler}",
+            extra=dict(
+                handler=self.name,
+                uri=uri,
+            ),
+        )
+
+    def on_ignore(self, message, uri, **kwargs):
+        self.logger.info(
+            "Ignored {handler}",
+            extra=dict(
+                handler=self.name,
+                uri=uri,
+            ),
+        )
+
+    def get_reason_to_skip(self, message, uri):
+        """
+        Some messages carry enough context that we can avoid resolving the URI entirely.
+
+        """
+        return None
+
+    def get_headers(self, message):
+        """
+        Generate headers to pass to downstream services.
+
+        """
+        return self.opaque.as_dict()
+
+    def handle(self, message, uri, **kwargs):
+        return True

--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -2,38 +2,13 @@
 Uri Handler base classes.
 
 """
-from abc import ABCMeta
-from re import search
-
-from inflection import titleize
-from microcosm.errors import LockedGraphError, NotBoundError
 from requests import codes, get
 
-from microcosm_pubsub.constants import DEFAULT_RESOURCE_CACHE_TTL
-from microcosm_pubsub.conventions.lifecycle import LifecycleChange
 from microcosm_pubsub.errors import Nack
+from microcosm_pubsub.handlers.base import PubSubHandler
 
 
-def resource_cache_whitelist_callable(media_type, uri):
-    """
-    Default resource cache whitelist callable implementation.
-
-    Only whitelists under the following conditions:
-    * verb is created
-    * resource is an event
-
-    """
-    if not media_type:
-        # Nb. likely to happen with mocks and tests.
-        return False
-
-    return all((
-        search(r"/[a-z]+_event/", uri),
-        search(r".{}.".format(LifecycleChange.Created), media_type),
-    ))
-
-
-class URIHandler(metaclass=ABCMeta):
+class URIHandler(PubSubHandler):
     """
     Base handler for URI-driven events.
 
@@ -42,120 +17,37 @@ class URIHandler(metaclass=ABCMeta):
     to query the existing URI to get more information (and to handle race conditions where the
     message was delivered before the resource was committed.)
 
-    There are five expected outcomes for this handler:
-      - Raising an error (e.g. a bug)
-      - Skipping the handlers (because the pubsub message carried enough information to bypass processing)
-      - Handling the message after fetching the resource by URI
-      - Ignore the message after fetching the resource by URI
-      - Raising a nack (e.g. because the resource was not committed yet)
-
-    The middle three cases are all handled here with the expectation that we produce *one* INFO-level
-    log per message processed (unless an error/nack is raised).
+    We still have the same five expected outcomes described in the base classe.
+    The only difference is that in this case skipping can happen either before fetching the resource
+    (using `get_reason_to_skip`) or afterwards.
 
     """
-    def __init__(
-        self,
-        graph,
-        retry_nack_timeout=1,
-        resource_nack_timeout=1,
-        resource_cache_enabled=True,
-        resource_cache_ttl=DEFAULT_RESOURCE_CACHE_TTL,
-        resource_cache_whitelist_callable=resource_cache_whitelist_callable,
-    ):
-        self.opaque = graph.opaque
-        self.retry_nack_timeout = retry_nack_timeout
-        self.resource_nack_timeout = resource_nack_timeout
-        self.resource_cache_ttl = resource_cache_ttl
-        self.resource_cache = self.get_resource_cache(graph) if resource_cache_enabled else None
-        self.resource_cache_whitelist_callable = resource_cache_whitelist_callable
+    def __init__(self, graph, **kwargs):
+        super().__init__(graph, **kwargs)
+        self.fetch_resource = graph.config.sqs_message_dispatcher.fetch_uri_resource
+
+    def __call__(self, message):
+        uri = message["uri"]
+        self._pre_handle(message, uri)
+
+        resource = None
+        # XXX: remove conditional and use base class instead post-POC
+        if self.fetch_resource:
+            resource = self.convert_resource(
+                self.get_resource(message, uri),
+            )
+
+        if self.handle(message, uri, resource=resource):
+            self.on_handle(message, uri, resourc=resource)
+            return True
+        else:
+            self.on_ignore(message, uri, resource=resource)
+            return False
 
     @property
     def nack_timeout(self):
         """Deprecated, use retry_nack_timeout"""
         return self.retry_nack_timeout
-
-    @property
-    def name(self):
-        return titleize(self.__class__.__name__)
-
-    @property
-    def nack_if_not_found(self):
-        return True
-
-    @property
-    def resource_type(self):
-        return dict
-
-    def get_resource_cache(self, graph):
-        try:
-            return graph.resource_cache
-        except (LockedGraphError, NotBoundError):
-            # Nb. if resource cache is globally disabled, will not be bound
-            return None
-
-    def __call__(self, message):
-        uri = message["uri"]
-        self.on_call(message, uri)
-
-        skip_reason = self.get_reason_to_skip(message, uri)
-        if skip_reason is not None:
-            self.on_skip(message, uri, skip_reason)
-            return False
-
-        resource = self.convert_resource(
-            self.get_resource(message, uri),
-        )
-
-        if self.handle(message, uri, resource):
-            self.on_handle(message, uri, resource)
-            return True
-        else:
-            self.on_ignore(message, uri, resource)
-            return False
-
-    def on_call(self, message, uri):
-        self.logger.debug(
-            "Starting {handler}",
-            extra=dict(
-                handler=self.name,
-                uri=uri,
-            ),
-        )
-
-    def on_skip(self, message, uri, reason):
-        self.logger.info(
-            "Skipping {handler} because {reason}",
-            extra=dict(
-                handler=self.name,
-                reason=reason,
-                uri=uri,
-            ),
-        )
-
-    def on_handle(self, message, uri, resource):
-        self.logger.debug(
-            "Handled {handler}",
-            extra=dict(
-                handler=self.name,
-                uri=uri,
-            ),
-        )
-
-    def on_ignore(self, message, uri, resource):
-        self.logger.info(
-            "Ignored {handler}",
-            extra=dict(
-                handler=self.name,
-                uri=uri,
-            ),
-        )
-
-    def get_reason_to_skip(self, message, uri):
-        """
-        Some messages carry enough context that we can avoid resolving the URI entirely.
-
-        """
-        return None
 
     def validate_changed_field(self, message, resource):
         if message.get('field_name') and self.nack_if_not_found:
@@ -196,17 +88,7 @@ class URIHandler(metaclass=ABCMeta):
 
         return response_json
 
-    def get_headers(self, message):
-        """
-        Generate headers to pass to downstream services.
-
-        """
-        return self.opaque.as_dict()
-
     def convert_resource(self, resource):
         if isinstance(self.resource_type, type) and isinstance(resource, self.resource_type):
             return resource
         return self.resource_type(**resource)
-
-    def handle(self, message, uri, resource):
-        return True

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "2.8.1"
+version = "2.9.0"
 
 setup(
     name=project,

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "microcosm-caching>=0.2.0",
         "microcosm-daemon>=1.0.0",
         "microcosm-logging>=1.3.0",
+        "tornado<6",
     ],
     extras_require={
         "metrics": "microcosm-metrics>=2.5.0",


### PR DESCRIPTION
Releases https://github.com/globality-corp/microcosm-pubsub/pull/203
**Why?**
This is part of POC to transition to handlers that don't fetch the published resource, and instead only use the message itself.

**What?**
- Add configuration value to bypass fetching the resource in URIHandler
- Add base handler that has the same behavior, and that will be used instead of URIHandler in the future.
