### PR TITLE
Exclude unknown field in message schemas

### DIFF
--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -5,6 +5,7 @@ Registry of SQS message handlers.
 from collections import defaultdict
 from inspect import isclass
 
+from marshmallow import EXCLUDE
 from microcosm.api import defaults
 from microcosm_logging.decorators import logger
 
@@ -94,7 +95,7 @@ class PubSubMessageSchemaRegistry:
         try:
             # use a concrete schema class if any
             schema_cls = self._mappings[matching_media_type]
-            schema = schema_cls()
+            schema = schema_cls(unknown=EXCLUDE)
         except KeyError:
             # use convention otherwise
             if self.lifecycle_change.Deleted in media_type.split("."):

--- a/microcosm_pubsub/tests/test_registry.py
+++ b/microcosm_pubsub/tests/test_registry.py
@@ -109,6 +109,15 @@ class TestDerivedPubSubMessageCodecRegistry:
         assert_that(schema, is_(instance_of(PubSubMessageCodec)))
         assert_that(schema.schema, is_(instance_of(ChangedURIMessageSchema)))
 
+    def test_serialize_unknown_field(self):
+        schema = self.registry.find(ChangedSchema.MEDIA_TYPE)
+        # No exception raised
+        schema.encode(dict(
+            foo="bar",
+            media_type=changed("Foo"),
+            uri="http://uri",
+        ))
+
 
 class TestDerivedSQSMessageHandlerRegistry:
 


### PR DESCRIPTION
Unknown fields don't matter much in the context of pubsub messages; we
should ignore them and not error. We used to have this but implicitly lost
it for deserialization in
https://github.com/globality-corp/microcosm-pubsub/pull/183/files#diff-aeca0c2c58f2b77be52bdd40f71d085eL105