### PR TITLE
Revert "Exclude unknown field in message schemas (#221)"

### DIFF
--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -5,7 +5,6 @@ Registry of SQS message handlers.
 from collections import defaultdict
 from inspect import isclass
 
-from marshmallow import EXCLUDE
 from microcosm.api import defaults
 from microcosm_logging.decorators import logger
 
@@ -95,7 +94,7 @@ class PubSubMessageSchemaRegistry:
         try:
             # use a concrete schema class if any
             schema_cls = self._mappings[matching_media_type]
-            schema = schema_cls(unknown=EXCLUDE)
+            schema = schema_cls()
         except KeyError:
             # use convention otherwise
             if self.lifecycle_change.Deleted in media_type.split("."):

--- a/microcosm_pubsub/tests/test_registry.py
+++ b/microcosm_pubsub/tests/test_registry.py
@@ -109,15 +109,6 @@ class TestDerivedPubSubMessageCodecRegistry:
         assert_that(schema, is_(instance_of(PubSubMessageCodec)))
         assert_that(schema.schema, is_(instance_of(ChangedURIMessageSchema)))
 
-    def test_serialize_unknown_field(self):
-        schema = self.registry.find(ChangedSchema.MEDIA_TYPE)
-        # No exception raised
-        schema.encode(dict(
-            foo="bar",
-            media_type=changed("Foo"),
-            uri="http://uri",
-        ))
-
 
 class TestDerivedSQSMessageHandlerRegistry:
 


### PR DESCRIPTION
This reverts commit 9df33231f15fcc7e9f65e6e49a0b55c9b623601d.

This causes issues in some downstream services, where we implicitly try
to perform this against non-marshmallow schemas.