### PR TITLE
Decouple pubsub message production and publishing

### DIFF
--- a/microcosm_pubsub/handlers/publish_batch_message.py
+++ b/microcosm_pubsub/handlers/publish_batch_message.py
@@ -8,7 +8,8 @@ from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.conventions import created
 from microcosm_pubsub.decorators import handles
-from microcosm_pubsub.producer import PubsubMessage, SNSProducer
+from microcosm_pubsub.producer import SNSProducer
+from microcosm_pubsub.published_message import PublishedMessage
 
 
 @binding("publish_message_batch")
@@ -22,7 +23,7 @@ class PublishBatchMessage:
     def __call__(self, message):
         messages = message["messages"]
         for message in messages:
-            pubsub_message = PubsubMessage(
+            pubsub_message = PublishedMessage(
                 media_type=message["media_type"],
                 message=message["message"],
                 message_attributes=message["message_attributes"],

--- a/microcosm_pubsub/published_message.py
+++ b/microcosm_pubsub/published_message.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from time import time
+from typing import Dict
+
+from microcosm.api import binding
+
+from microcosm_pubsub.constants import PUBLISHED_KEY
+
+
+@dataclass
+class PublishedMessage:
+    """
+    Container class encapsulating all of the necessary components for
+    publishing a given message
+
+    """
+    media_type: str
+    message: str
+    opaque_data: dict
+
+    # Deprecated: those attributes are SNS-specific and will be removed from this class
+    message_attributes: Dict[str, Dict[str, str]] = None
+    topic_arn: str = None
+
+
+@binding("published_message_builder")
+class PublishedMessageBuilder:
+    def __init__(self, graph):
+        self.opaque = graph.opaque
+        self.pubsub_message_schema_registry = graph.pubsub_message_schema_registry
+
+    def __call__(self, media_type, uri=None, opaque_data=None, **kwargs) -> PublishedMessage:
+        """
+        Build a message for publishing
+
+        """
+        if opaque_data is None:
+            opaque_data = dict()
+
+        if self.opaque is not None:
+            opaque_data.update(self.opaque.as_dict())
+
+        opaque_data[PUBLISHED_KEY] = str(time())
+
+        message = self.pubsub_message_schema_registry.find(media_type).encode(
+            opaque_data=opaque_data,
+            media_type=media_type,
+            uri=uri,
+            **kwargs
+        )
+        return PublishedMessage(
+            media_type=media_type,
+            message=message,
+            opaque_data=opaque_data,
+        )

--- a/microcosm_pubsub/published_message.py
+++ b/microcosm_pubsub/published_message.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from time import time
-from typing import Dict
+from typing import Dict, Optional
 
 from microcosm.api import binding
 
@@ -19,8 +19,8 @@ class PublishedMessage:
     opaque_data: dict
 
     # Deprecated: those attributes are SNS-specific and will be removed from this class
-    message_attributes: Dict[str, Dict[str, str]] = None
-    topic_arn: str = None
+    message_attributes: Optional[Dict[str, Dict[str, str]]] = None
+    topic_arn: Optional[str] = None
 
 
 @binding("published_message_builder")

--- a/microcosm_pubsub/tests/test_published_message.py
+++ b/microcosm_pubsub/tests/test_published_message.py
@@ -1,0 +1,78 @@
+from json import loads
+from unittest.mock import ANY, patch
+
+from marshmallow import fields
+import microcosm.opaque  # noqa
+from hamcrest import (
+    assert_that,
+    has_entries,
+    has_properties,
+)
+from microcosm.api import create_object_graph
+
+import microcosm_pubsub.published_message  # noqa: F401
+from microcosm_pubsub.constants import PUBLISHED_KEY
+from microcosm_pubsub.codecs import PubSubMessageSchema, PubSubMessageCodec
+
+
+class MessageSchema(PubSubMessageSchema):
+    name = fields.String()
+
+    MEDIA_TYPE = "foo.bar.media_type"
+
+
+def test_build_message():
+    graph = create_object_graph("example", testing=True)
+    graph.use(
+        "opaque",
+        "published_message_builder",
+        "pubsub_message_schema_registry",
+    )
+    with patch.object(graph.pubsub_message_schema_registry, "find") as mocked_find:
+        mocked_find.return_value = PubSubMessageCodec(MessageSchema())
+        message_1 = graph.published_message_builder(
+            media_type="foo.bar.media_type",
+            name="foo",
+            uri="http://uri",
+        )
+        assert_that(
+            message_1,
+            has_properties(
+                media_type="foo.bar.media_type",
+                message=ANY,
+                opaque_data={PUBLISHED_KEY: ANY}
+            ),
+        )
+
+        assert_that(
+            loads(message_1.message),
+            has_entries(
+                mediaType="foo.bar.media_type",
+                name="foo",
+                opaqueData={PUBLISHED_KEY: ANY}
+            ),
+        )
+
+        message_2 = graph.published_message_builder(
+            media_type="foo.bar.media_type",
+            name="foo",
+            uri="http://uri",
+            opaque_data=dict(bar="baz")
+        )
+        assert_that(
+            message_2,
+            has_properties(
+                media_type="foo.bar.media_type",
+                message=ANY,
+                opaque_data={PUBLISHED_KEY: ANY, "bar": "baz"},
+            ),
+        )
+
+        assert_that(
+            loads(message_2.message),
+            has_entries(
+                mediaType="foo.bar.media_type",
+                name="foo",
+                opaqueData={PUBLISHED_KEY: ANY, "bar": "baz"}
+            ),
+        )

--- a/microcosm_pubsub/tests/test_published_message.py
+++ b/microcosm_pubsub/tests/test_published_message.py
@@ -1,18 +1,14 @@
 from json import loads
 from unittest.mock import ANY, patch
 
-from marshmallow import fields
 import microcosm.opaque  # noqa
-from hamcrest import (
-    assert_that,
-    has_entries,
-    has_properties,
-)
+from hamcrest import assert_that, has_entries, has_properties
+from marshmallow import fields
 from microcosm.api import create_object_graph
 
 import microcosm_pubsub.published_message  # noqa: F401
+from microcosm_pubsub.codecs import PubSubMessageCodec, PubSubMessageSchema
 from microcosm_pubsub.constants import PUBLISHED_KEY
-from microcosm_pubsub.codecs import PubSubMessageSchema, PubSubMessageCodec
 
 
 class MessageSchema(PubSubMessageSchema):


### PR DESCRIPTION
**Why?**
We have coupled building the content of a message with publishing it, when there is no need to.
The metadata accompanying the message may vary depending on the needs of the publishing library, but the core content of a message won't.

**What?**
- Create message builder component external to `SNSProducer`.
- Mark SNS-specific attribute `topic_arns` and `message_attributes` of `PubsubMessage` as deprecated.
- Change `SNSProducer` code to work with message content being passed in, and keep compatibility with existing mechanism.