### PR TITLE
Add media type field in message result

### DIFF
--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -146,7 +146,11 @@ class MessageHandlingResult:
             self.result.level,
             entry,
             exc_info=self.exc_info,
-            extra={**opaque.as_dict(), **self.extra},
+            extra={
+                "media_type": self.media_type,
+                **opaque.as_dict(),
+                **self.extra,
+            },
         )
 
     def resolve(self, message):

--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -204,6 +204,7 @@ class TestMessageHandlingResult:
         ).resolve(self.message)
 
         result.extra = dict(
+            media_type="foo.created",
             foo="bar"
         )
         self.graph.opaque["foo"] = "baz"
@@ -211,5 +212,5 @@ class TestMessageHandlingResult:
         # This doesn't error
         result.log(
             self.graph.logger,
-            self.graph.opaque
+            self.graph.opaque,
         )


### PR DESCRIPTION
Add the message `media_type` to the `extra` dictionary when logging the result, so as to get it as a searchable field in the logged json.