### PR TITLE
Don't validate against message schema on serialization

### DIFF
--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -79,12 +79,8 @@ class PubSubMessageCodec:
         message = dct.copy() if dct else dict()
         message.update(kwargs)
 
+        # Note that `dump` doesn't perform any validation
         dumped = self.schema.dump(message)
-
-        # NB: Schema dump doesn't run validation
-        errors = self.schema.validate(dumped)
-        if errors:
-            raise ValidationError(message=errors)
 
         # Dump to string
         return dumps(dumped)

--- a/microcosm_pubsub/tests/test_codecs.py
+++ b/microcosm_pubsub/tests/test_codecs.py
@@ -53,16 +53,6 @@ def test_encode():
     })))
 
 
-def test_encode_missing_field():
-    """
-    An invalid message will raise errors.
-
-    """
-    graph = create_object_graph("example", testing=True)
-    codec = graph.pubsub_message_schema_registry.find(DerivedSchema.MEDIA_TYPE)
-    assert_that(calling(codec.encode), raises(ValidationError))
-
-
 def test_decode():
     """
     A message will be decoded according to its schema.


### PR DESCRIPTION
**Why?**
`schema.dump` in Marshmallow doesn't run any validation of the data against the schema. The stated rationale for this is
"I need to validate data from the outside world, but not from my own data" (see this [GitHub issue](https://github.com/marshmallow-code/marshmallow/issues/682#issuecomment-332758061)).

In the past we decided to bridge that gap by explictly calling `schema.validate`. However, that is awkward in two ways:
- We don't do that for the API layer (see `microcosm-flask`); which makes our approach inconsistent.
- The validation code in Marshmallow is oriented towards deserialization (follow from [this line](https://github.com/marshmallow-code/marshmallow/blob/dev/src/marshmallow/schema.py#L794). This means that any field with `dump_only` is ignored in the schema when validating. As a consequence, it's just not possible to properly validate on serialization without working around Marshmallow conventions.

I propose making `microcosm-pubsub` consistent with Marshmallow and `microcosm-flask`, and drop validation on serializing the message.

**What?**
Remove call to `schema.validate` in coded `encode` method.