### PR TITLE
Instantiate schemas with unknown=EXCLUDE

### DIFF
--- a/microcosm_pubsub/codecs.py
+++ b/microcosm_pubsub/codecs.py
@@ -79,8 +79,12 @@ class PubSubMessageCodec:
         message = dct.copy() if dct else dict()
         message.update(kwargs)
 
-        # Note that `dump` doesn't perform any validation
         dumped = self.schema.dump(message)
+
+        # NB: Schema dump doesn't run validation
+        errors = self.schema.validate(dumped)
+        if errors:
+            raise ValidationError(message=errors)
 
         # Dump to string
         return dumps(dumped)

--- a/microcosm_pubsub/registry.py
+++ b/microcosm_pubsub/registry.py
@@ -5,6 +5,7 @@ Registry of SQS message handlers.
 from collections import defaultdict
 from inspect import isclass
 
+from marshmallow import EXCLUDE
 from microcosm.api import defaults
 from microcosm_logging.decorators import logger
 
@@ -94,7 +95,7 @@ class PubSubMessageSchemaRegistry:
         try:
             # use a concrete schema class if any
             schema_cls = self._mappings[matching_media_type]
-            schema = schema_cls()
+            schema = schema_cls(unknown=EXCLUDE)
         except KeyError:
             # use convention otherwise
             if self.lifecycle_change.Deleted in media_type.split("."):

--- a/microcosm_pubsub/tests/test_codecs.py
+++ b/microcosm_pubsub/tests/test_codecs.py
@@ -53,6 +53,16 @@ def test_encode():
     })))
 
 
+def test_encode_missing_field():
+    """
+    An invalid message will raise errors.
+
+    """
+    graph = create_object_graph("example", testing=True)
+    codec = graph.pubsub_message_schema_registry.find(DerivedSchema.MEDIA_TYPE)
+    assert_that(calling(codec.encode), raises(ValidationError))
+
+
 def test_decode():
     """
     A message will be decoded according to its schema.

--- a/microcosm_pubsub/tests/test_registry.py
+++ b/microcosm_pubsub/tests/test_registry.py
@@ -109,6 +109,15 @@ class TestDerivedPubSubMessageCodecRegistry:
         assert_that(schema, is_(instance_of(PubSubMessageCodec)))
         assert_that(schema.schema, is_(instance_of(ChangedURIMessageSchema)))
 
+    def test_serialize_unknown_field(self):
+        schema = self.registry.find(ChangedSchema.MEDIA_TYPE)
+        # No exception raised
+        schema.encode(dict(
+            foo="bar",
+            media_type=changed("Foo"),
+            uri="http://uri",
+        ))
+
 
 class TestDerivedSQSMessageHandlerRegistry:
 


### PR DESCRIPTION
**Why?**
Validating schemas on serialization using Marshmallow presents
some issues, due to the fact that it is not in line with Marshmallow's
philosophy (see this [GitHub
issue](https://github.com/marshmallow-code/marshmallow/issues/682)). The
main issue is that a schema's `validate` method ignores `dump_only` fields,
so those are treated as unknown fields. However, validation is still useful
in highlighting fields that should be marked as nullable in the schema.

**What?**
- Bring back schema validation on serialization.
- Use `unknown=EXCLUDE` on schema instantiation, meaning that unknown
fields won't trigger errors.