### PR TITLE
Feature/devops 1413 read sqs event from json

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.17.0
+current_version = 2.17.1
 commit = False
 tag = False
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.14.0
+current_version = 2.17.0
 commit = False
 tag = False
 

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -10,7 +10,7 @@ from microcosm.api import defaults, typed
 from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.backoff import BackoffPolicy
-from microcosm_pubsub.reader import SQSFileReader, SQSStdInReader
+from microcosm_pubsub.reader import SQSFileReader, SQSStdInReader, SQSJsonReader
 
 
 STDIN = "STDIN"
@@ -140,10 +140,13 @@ def configure_sqs_consumer(graph):
 
     """
     sqs_queue_url = graph.config.sqs_consumer.sqs_queue_url
+    sqs_event = graph.config.sqs_consumer.sqs_event
 
     if graph.metadata.testing or sqs_queue_url == "test":
         from unittest.mock import MagicMock
         sqs_client = MagicMock()
+    elif sqs_event: # AWS Lambda invocation
+        sqs_client = SQSJsonReader(sqs_event)
     elif sqs_queue_url == STDIN:
         sqs_client = SQSStdInReader()
     elif is_file(sqs_queue_url):

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -10,7 +10,7 @@ from microcosm.api import defaults, typed
 from microcosm_logging.decorators import logger
 
 from microcosm_pubsub.backoff import BackoffPolicy
-from microcosm_pubsub.reader import SQSFileReader, SQSStdInReader, SQSJsonReader
+from microcosm_pubsub.reader import SQSFileReader, SQSJsonReader, SQSStdInReader
 
 
 STDIN = "STDIN"

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -145,7 +145,7 @@ def configure_sqs_consumer(graph):
     if graph.metadata.testing or sqs_queue_url == "test":
         from unittest.mock import MagicMock
         sqs_client = MagicMock()
-    elif sqs_event: # AWS Lambda invocation
+    elif sqs_event:  # AWS Lambda invocation
         sqs_client = SQSJsonReader(sqs_event)
     elif sqs_queue_url == STDIN:
         sqs_client = SQSStdInReader()

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -12,10 +12,10 @@ from microcosm_pubsub.envelope import NaiveSQSEnvelope, SQSEnvelope
 
 class ConsumerDaemon(Daemon):
 
-    def __init__(self, event={}):
+    def __init__(self, event=None):
         super().__init__()
         self.bound_handlers = None
-        self.sqs_event = event
+        self.sqs_event = event or {}
 
     def make_arg_parser(self):
         parser = super().make_arg_parser()

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -12,9 +12,10 @@ from microcosm_pubsub.envelope import NaiveSQSEnvelope, SQSEnvelope
 
 class ConsumerDaemon(Daemon):
 
-    def __init__(self):
+    def __init__(self, event={}):
         super().__init__()
         self.bound_handlers = None
+        self.sqs_event = event
 
     def make_arg_parser(self):
         parser = super().make_arg_parser()
@@ -68,7 +69,19 @@ class ConsumerDaemon(Daemon):
                     strategy_name=self.args.envelope,
                 ),
             )
-
+        # for AWS Lambda
+        # event is argument of handler invoked by SQS Query
+        # we don't use command line args here
+        if self.sqs_event:
+            config.update(
+                sqs_envelope=dict(
+                    strategy_name=NaiveSQSEnvelope.__name__,
+                ),
+                sqs_consumer=dict(
+                    sqs_event=self.sqs_event,
+                    sqs_queue_url="",
+                )
+            )            
         return config
 
     @property

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -53,6 +53,7 @@ class ConsumerDaemon(Daemon):
                 ),
                 sqs_consumer=dict(
                     sqs_queue_url=STDIN,
+                    sqs_event=""
                 ),
             )
 
@@ -60,6 +61,7 @@ class ConsumerDaemon(Daemon):
             config.update(
                 sqs_consumer=dict(
                     sqs_queue_url=self.args.sqs_queue_url,
+                    sqs_event=""
                 ),
             )
 
@@ -81,7 +83,7 @@ class ConsumerDaemon(Daemon):
                     sqs_event=self.sqs_event,
                     sqs_queue_url="",
                 )
-            )            
+            )
         return config
 
     @property

--- a/microcosm_pubsub/daemon.py
+++ b/microcosm_pubsub/daemon.py
@@ -72,7 +72,12 @@ class ConsumerDaemon(Daemon):
                 ),
             )
         # for AWS Lambda
-        # event is argument of handler invoked by SQS Query
+        # SQS message comes as function argument
+        # e.g
+        # ```
+        # def handler(event, context):
+        #     # processing event
+        # ```
         # we don't use command line args here
         if self.sqs_event:
             config.update(

--- a/microcosm_pubsub/reader.py
+++ b/microcosm_pubsub/reader.py
@@ -64,3 +64,22 @@ class SQSStdInReader:
 
     def change_message_visibility(self, *args, **kwargs):
         pass
+
+
+class SQSJsonReader:
+    """
+    Read message data from a JSON string.
+    Accepts single message, but appended to list for backward compatibility
+
+    """
+    def __init__(self, message):
+        self.message = message
+
+    def receive_message(self, **kwargs):
+        return dict(Messages=[self.message])
+
+    def delete_message(self, *args, **kwargs):
+        pass
+
+    def change_message_visibility(self, *args, **kwargs):
+        pass

--- a/microcosm_pubsub/tests/test_consumer.py
+++ b/microcosm_pubsub/tests/test_consumer.py
@@ -12,8 +12,9 @@ from hamcrest import (
 )
 from microcosm.caching import NaiveCache
 
-from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon
 from microcosm_pubsub.reader import SQSJsonReader
+from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon
+
 
 MESSAGE_ID = "message-id"
 RECEIPT_HANDLE = "receipt-handle"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "2.17.0"
+version = "2.17.1"
 
 setup(
     name=project,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "2.16.0"
+version = "2.17.0"
 
 setup(
     name=project,


### PR DESCRIPTION
Part of implementing Serverless Daemons feature
https://globality.atlassian.net/wiki/spaces/D/pages/1199866837/Tech+Design+Running+Daemons+with+AWS+Lambda+Serverless

Add an optional argument to ConsumerDaemon.
Add SQSJsonReader to handle messages from SQS
