### PR TITLE
Add support for sentry to microcosm_pubsub

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ handlers will be a class with its own `@binding` to pass other collaborators:
             return True
 
 
-Subclass the `ConsumerDaemon` and override any required attribtes (notably `name`):
+Subclass the `ConsumerDaemon` and override any required attributes (notably `name`):
 
     class SimpleConsumerDaemon(ConsumerDaemon):
 

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -61,6 +61,7 @@ class SQSMessageDispatcher:
         self.send_metrics = graph.pubsub_send_metrics
         self.send_batch_metrics = graph.pubsub_send_batch_metrics
         self.max_processing_attempts = graph.config.sqs_message_dispatcher.message_max_processing_attempts
+        self.sentry_enabled = graph.sentry_logging.enabled
 
     def handle_batch(self, bound_handlers) -> List[MessageHandlingResult]:
         """
@@ -127,6 +128,9 @@ class SQSMessageDispatcher:
             instance.log(
                 logger=self.choose_logger(handler),
                 opaque=self.opaque,
+            )
+            instance.error_reporting(
+                self.sentry_enabled, self.opaque,
             )
             instance.resolve(message)
             return instance

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -153,6 +153,18 @@ class MessageHandlingResult:
             },
         )
 
+    def error_reporting(self, sentry_enabled, opaque):
+        if not sentry_enabled:
+            return
+        from sentry_sdk import capture_exception
+        from sentry_sdk import configure_scope
+        opaque = opaque.as_dict()
+        with configure_scope() as scope:
+            scope.set_tag("x-request-id", opaque.get("X-Request-Id"))
+            scope.set_tag("message-id", opaque.get("message_id"))
+            scope.set_tag("media-type", opaque.get("media_type"))
+            capture_exception(self.exc_info)
+
     def resolve(self, message):
         if self.result.retry:
             message.nack(self.retry_timeout_seconds)

--- a/microcosm_pubsub/sentry.py
+++ b/microcosm_pubsub/sentry.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+from os import environ
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+from microcosm.decorators import defaults
+from microcosm.object_graph import ObjectGraph
+from microcosm_logging.decorators import logger
+from sentry_sdk.utils import BadDsn
+
+
+@dataclass
+class SentryConfig:
+    dsn: Optional[str] = None
+    enabled: bool = False
+    client: Optional[Any] = None
+
+
+def before_send(event, hint):
+    """
+    Before sending a event to sentry scrub all values that are non-uuid data from the event
+
+    """
+    for exception in event["exception"]["values"]:
+        for frame in exception["stacktrace"]["frames"]:
+            for var_name, value in frame["vars"].items():
+                if var_name in ["self", "cls"]:
+                    continue
+                elif isinstance(value, str):
+                    if value.startswith("<function "):
+                        continue
+                    elif var_name.endswith("_id"):
+                        continue
+                frame["vars"][var_name] = "<redacted>"
+    return event
+
+
+@defaults(
+    enabled=False,
+    dsn=None,
+)
+@logger
+def configure_sentry(graph: ObjectGraph):
+    enabled, dsn, sentry = False, None, None
+    if graph.config.sentry_logging.enabled and graph.config.sentry_logging.dsn:
+        enabled = graph.config.sentry_logging.enabled
+        dsn = graph.config.sentry_logging.dsn
+        if graph.metadata.testing:
+            sentry = MagicMock()
+        else:
+            import sentry_sdk
+            try:
+                sentry = sentry_sdk.init(
+                    graph.config.sentry_logging.dsn,
+                    server_name=f"{graph.metadata.name}_daemon",
+                    release=graph.config.build_info_convention.sha1,
+                    environment=environ.get("MICROCOSM_ENVIRONMENT") or "undefined",
+                    before_send=before_send,
+                )
+            except BadDsn:
+                enabled, dsn, sentry = False, None, None
+                configure_sentry.logger.error("Bad DSN value set")
+
+    return SentryConfig(
+        dsn=dsn,
+        enabled=enabled,
+        client=sentry
+    )

--- a/microcosm_pubsub/tests/sentry_fixture.py
+++ b/microcosm_pubsub/tests/sentry_fixture.py
@@ -1,0 +1,79 @@
+sample_event = {
+    'level': 'error',
+    'exception': {
+        'values': [
+            {
+                'module': None, 'type': 'TypeError', 'value': 'Testing stuff', 'mechanism': None,
+                'stacktrace': {
+                    'frames': [
+                        {
+                            'filename': 'microcosm_pubsub/result.py',
+                            'abs_path': '/Users/rob/dev/microcosm-pubsub/microcosm_pubsub/result.py',
+                            'function': 'invoke',
+                            'module': 'microcosm_pubsub.result', 'lineno': 85,
+                            'pre_context': [
+                                '    retry_timeout_seconds: Optional[int] = None', '', '    @classmethod',
+                                '    def invoke(cls, handler, message: SQSMessage):', '        try:'
+                            ],
+                            'context_line': '            success = handler(message.content)',
+                            'post_context': [
+                                '            return cls.from_result(message, bool(success))',
+                                '        except Exception as error:',
+                                '            return cls.from_error(message, error)',
+                                '',
+                                '    @classmethod'
+                            ],
+                            'vars': {
+                                'cls': "<class 'microcosm_pubsub.result.MessageHandlingResult'>",
+                                'handler': '<function context_logger.<locals>.wrapped at 0x109422ef0>',
+                                'message': '<microcosm_pubsub.message.SQSMessage object at 0x10952bcd0>'
+                            },
+                            'in_app': True},
+                        {
+                            'filename': 'test/daemon/test_daemon/handlers/test_handler.py',
+                            'abs_path': '/Users/rob/dev/test/daemon/test_daemon/handlers/test_handler.py',
+                            'function': 'do_something',
+                            'module': 'test.daemon.test_daemon.handlers.test_handler', 'lineno': 50,
+                            'pre_context': [
+                                '    def resource_type(self):',
+                                '        return self.test.get_model("TestHandler")',
+                                '', '    @extracts("something")',
+                            ],
+                            'context_line': '        raise TypeError("Testing stuff")',
+                            'post_context': ['    @extracts("something")'],
+                            'vars': {
+                                'self':
+                                    '<test.daemon.test_daemon.handlers.test_handler.TestHandler object at 0x10953cbd0>',
+                                'something_id': "'1f40066c-f457-41b3-aa4c-72cdac5146e4'",
+                                'project_description': "'this is some secret info'",
+                                'other_id': "'70375dff-2d46-40c4-a1d1-f5d49a25698d'"
+                            }, 'in_app': True
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    'event_id': 'c25a874a6d964c8b832e00c10009d9bc', 'timestamp': '2020-05-16T11:01:35.987342Z',
+    'breadcrumbs': [
+        {'ty': 'log', 'level': 'info', 'category': 'something', 'message': 'Starting daemon test',
+         'timestamp': '2020-05-16T11:01:35.935538Z', 'data': {}, 'type': 'default'},
+        {'ty': 'log', 'level': 'warning', 'category': 'TestHandler',
+         'message': 'Result for media type: application/vnd.globality.pubsub._.created.do_something was : FAILED ',
+         'timestamp': '2020-05-16T11:01:35.983545Z',
+         'data': {'media_type': 'application/vnd.globality.pubsub._.created.do_something',
+                  'message_id': 'message-id-b7fa5993-a966-4390-a6b1-ed9eb5026134', 'X-Request-Ttl': '31',
+                  'uri': 'http://localhost:5452/api/v2/message/6dee4da6-8af1-4636-93b6-7770bc6990bc',
+                  'handler': 'Handler Test', 'elapsed_time': 47.17707633972168}, 'type': 'default'}
+    ],
+    'tags': {'x-request-id': None, 'message-id': 'message-id-b7fa5993-a966-4390-a6b1-ed9eb5026134', 'media-type': None},
+    'contexts': {'runtime': {'name': 'CPython', 'version': '3.7.4',
+                             'build': ''}},
+    'modules': {'microcosm-pubsub': '2.17.0'},
+    'extra': {'sys.argv': []}, 'environment': 'localhost',
+    'server_name': 'some_daemon',
+    'sdk': {'name': 'sentry.python', 'version': '0.14.4',
+            'packages': [{'name': 'pypi:sentry-sdk', 'version': '0.14.4'}],
+            'integrations': []},
+    'platform': 'python'
+}

--- a/microcosm_pubsub/tests/test_sentry.py
+++ b/microcosm_pubsub/tests/test_sentry.py
@@ -1,0 +1,78 @@
+"""
+Sentry integration tests.
+
+"""
+from hamcrest import assert_that, equal_to, is_
+from microcosm.api import create_object_graph
+
+from microcosm_pubsub.sentry import before_send
+from microcosm_pubsub.tests.sentry_fixture import sample_event
+
+
+def test_sentry_config_bad_dsn():
+    def loader(metadata):
+        return dict(
+            sentry_logging=dict(
+                enabled=True,
+                dsn="invalid schema",
+            ),
+            build_info_convention=dict(
+                sha1="some-sha",
+            )
+        )
+
+    graph = create_object_graph("example", testing=False, loader=loader)
+    assert_that(graph.sentry_logging.enabled, is_(equal_to(False)))
+
+
+def test_sentry_client_loaded_to_graph_testing():
+    def loader(metadata):
+        return dict(
+            sentry_logging=dict(
+                dsn="topic",
+                enabled=True,
+            )
+        )
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+    assert_that(
+        graph.sentry_logging.dsn,
+        is_(equal_to("topic"))
+    )
+
+
+def test_sentry_client_default_to_None_no_dsn_set():
+    def loader(metadata):
+        return dict()
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+
+    assert_that(
+        graph.sentry_logging.enabled,
+        is_(equal_to(False))
+    )
+
+
+def test_before_send_data_removal():
+    filtered_event = before_send(sample_event, None)
+    filtered_stacktrace = filtered_event["exception"]["values"][0]["stacktrace"]["frames"]
+
+    assert_that(
+        filtered_stacktrace[0]["vars"],
+        is_(equal_to(
+            {'cls': "<class 'microcosm_pubsub.result.MessageHandlingResult'>",
+             'handler': '<function context_logger.<locals>.wrapped at 0x109422ef0>',
+             'message': '<redacted>'}
+        ))
+    )
+    assert_that(
+        filtered_stacktrace[1]["vars"],
+        is_(equal_to(
+            {
+                'self': '<test.daemon.test_daemon.handlers.test_handler.TestHandler object at 0x10953cbd0>',
+                'something_id': "'1f40066c-f457-41b3-aa4c-72cdac5146e4'",
+                'project_description': "<redacted>",
+                'other_id': "'70375dff-2d46-40c4-a1d1-f5d49a25698d'"
+            }
+        ))
+    )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "microcosm-caching>=0.2.0",
         "microcosm-daemon>=1.0.0",
         "microcosm-logging>=1.3.0",
+        "sentry-sdk>=0.14.4",
     ],
     extras_require={
         "metrics": "microcosm-metrics>=2.5.0",
@@ -52,6 +53,7 @@ setup(
             "sqs_message_handler_registry = microcosm_pubsub.registry:configure_handler_registry",
             "sns_producer = microcosm_pubsub.producer:configure_sns_producer",
             "sns_topic_arns = microcosm_pubsub.producer:configure_sns_topic_arns",
+            "sentry_logging = microcosm_pubsub.sentry:configure_sentry",
         ]
     },
     tests_require=[


### PR DESCRIPTION
Why?
- easier debugging of DLQ issues
- gather data on common error types
- persistent, errors are retained after DLQ is cleared

What?
- Add ability for sentry dsn to be configured and used by a pubsub consumer to report errors 
- scrub data before sending to sentry, anything that isn't a `uuid` or known type such as `self`, `cls`, `<function` has there values redacted before sending to sentry

Questions:
- data scrubbing. More/less
- aligning on metadata to populate. Easier tracing of how an error occurs across projects.

