### PR TITLE
Only report Error state results to sentry

### DIFF
--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -96,7 +96,7 @@ class SQSConsumer:
              the sqs consumer's config and override the SQS queue's visibility with a known, smallish value.
 
              We choose the latter under the assumption that 30s is too long to reprocess most messages
-             as a defult and that long-running handlers will be configured accordingly (see: 2a).
+             as a default and that long-running handlers will be configured accordingly (see: 2a).
 
         Therefore: we always invoke `change_message_visibility`
 

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -130,7 +130,8 @@ class SQSMessageDispatcher:
                 opaque=self.opaque,
             )
             instance.error_reporting(
-                self.sentry_enabled, self.opaque,
+                sentry_enabled=self.sentry_enabled,
+                opaque=self.opaque,
             )
             instance.resolve(message)
             return instance

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -154,13 +154,13 @@ class MessageHandlingResult:
         )
 
     def error_reporting(self, sentry_enabled, opaque):
-        if any([
-            not sentry_enabled,
-            self.result not in [
+        if not all([
+            sentry_enabled,
+            self.result in [
                 MessageHandlingResultType.FAILED,
                 MessageHandlingResultType.EXPIRED,
             ],
-            not self.exc_info,
+            self.exc_info,
         ]):
             return
         self._report_error(opaque)

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -154,8 +154,18 @@ class MessageHandlingResult:
         )
 
     def error_reporting(self, sentry_enabled, opaque):
-        if not sentry_enabled:
+        if any([
+            not sentry_enabled,
+            self.result not in [
+                MessageHandlingResultType.FAILED,
+                MessageHandlingResultType.EXPIRED,
+            ],
+            not self.exc_info,
+        ]):
             return
+        self._report_error(opaque)
+
+    def _report_error(self, opaque):
         from sentry_sdk import capture_exception
         from sentry_sdk import configure_scope
         opaque = opaque.as_dict()

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,6 @@ setup(
         "coverage>=3.7.1",
         "parameterized>=0.7.0",
         "PyHamcrest>=1.8.5",
+        "parameterized>=0.7.4",
     ],
 )


### PR DESCRIPTION
Why?
- Handler can exit early with more cases than just error, such as Nack, SkipMessage this was generating events in sentry that were not beneficial

What?
- Only report error to sentry if result_type is `FAILED` or `EXPIRED`
- Only report error if there is an `exc_info` present