### PR TITLE
Give sentry config a unique graph entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,19 +149,19 @@ Application using `microcosm_pubsub`.
 }
 ```
 
-- `sentry_logging.enabled` - boolean
-- `sentry_logging.dsn` - url - the url of the project that errors will be
+- `sentry_logging_pubsub.enabled` - boolean
+- `sentry_logging_pubsub.dsn` - url - the url of the project that errors will be
  sent to
-- `sentry_logging.custom_tags_mapping` - key/value mapping - defines what data
+- `sentry_logging_pubsub.custom_tags_mapping` - key/value mapping - defines what data
  stored in `Opaque` data should be sent to sentry and what the tag in sentry
  should be.
-- `sentry_logging.custom_user_id` - string - defines what data within `Opaque`
+- `sentry_logging_pubsub.custom_user_id` - string - defines what data within `Opaque`
 should be sent to `sentry` as `user.id`.
 
 ### Overriding the default before_send
 `before_send` is a function that runs before each event that is sent to sentry.
 It is used to remove sensitive data, the default one provided is reasonably
-strict removing most data in a quite a generic way. To customise this behaviour 
+strict removing most data in a quite a generic way. To customise this behaviour
 in an Application the following can be done.
 
 ```python
@@ -179,4 +179,3 @@ def custom_before_send_factory(graph):
 graph = create_object_graph("example")
 graph.use("sentry_before_send")
 ```
-

--- a/microcosm_pubsub/dispatcher.py
+++ b/microcosm_pubsub/dispatcher.py
@@ -44,7 +44,7 @@ from microcosm_pubsub.result import MessageHandlingResult, MessageHandlingResult
 @logger
 @defaults(
     # Number of failed attempts after which the message stops being processed
-    message_max_processing_attempts=typed(int, default_value=None)
+    message_max_processing_attempts=typed(int, default_value=None),
 )
 class SQSMessageDispatcher:
     """
@@ -61,7 +61,7 @@ class SQSMessageDispatcher:
         self.send_metrics = graph.pubsub_send_metrics
         self.send_batch_metrics = graph.pubsub_send_batch_metrics
         self.max_processing_attempts = graph.config.sqs_message_dispatcher.message_max_processing_attempts
-        self.sentry_config = graph.sentry_logging
+        self.sentry_config = graph.sentry_logging_pubsub
 
     def handle_batch(self, bound_handlers) -> List[MessageHandlingResult]:
         """

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -22,7 +22,7 @@ from microcosm_pubsub.errors import (
     TTLExpired,
 )
 from microcosm_pubsub.message import SQSMessage
-from microcosm_pubsub.sentry import SentryConfig
+from microcosm_pubsub.sentry import SentryConfigPubsub
 
 
 @dataclass
@@ -156,7 +156,7 @@ class MessageHandlingResult:
             },
         )
 
-    def error_reporting(self, sentry_config: SentryConfig, opaque: Opaque) -> None:
+    def error_reporting(self, sentry_config: SentryConfigPubsub, opaque: Opaque) -> None:
         if not all([
             sentry_config.enabled,
             self.result in [

--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -16,7 +16,7 @@ from microcosm_pubsub.errors import (
 )
 from microcosm_pubsub.message import SQSMessage
 from microcosm_pubsub.result import MessageHandlingResult, MessageHandlingResultType
-from microcosm_pubsub.sentry import SentryConfig
+from microcosm_pubsub.sentry import SentryConfigPubsub
 from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon
 
 
@@ -209,7 +209,7 @@ class TestMessageHandlingResult:
 
         result.extra = dict(
             media_type="foo.created",
-            foo="bar"
+            foo="bar",
         )
         self.graph.opaque["foo"] = "baz"
 
@@ -229,7 +229,7 @@ class TestMessageHandlingResult:
     ])
     def test_error_reporting_only_sends_on_relevant_result_type(self, result_type, error_reported):
         result = MessageHandlingResult(result=result_type, media_type="media", exc_info=(1, 2, 3))
-        sentry_config = SentryConfig(enabled=True)
+        sentry_config = SentryConfigPubsub(enabled=True)
         with patch.object(result, "_report_error") as mock_report:
             result.error_reporting(sentry_config, self.graph.opaque)
 

--- a/microcosm_pubsub/tests/test_sentry.py
+++ b/microcosm_pubsub/tests/test_sentry.py
@@ -23,13 +23,13 @@ def test_sentry_config_bad_dsn():
         )
 
     graph = create_object_graph("example", testing=False, loader=loader)
-    assert_that(graph.sentry_logging.enabled, is_(equal_to(False)))
+    assert_that(graph.sentry_logging_pubsub.enabled, is_(equal_to(False)))
 
 
 def test_sentry_client_loaded_to_graph_testing():
     def loader(metadata):
         return dict(
-            sentry_logging=dict(
+            sentry_logging_pubsub=dict(
                 dsn="topic",
                 enabled=True,
             ),
@@ -37,7 +37,7 @@ def test_sentry_client_loaded_to_graph_testing():
 
     graph = create_object_graph("example", testing=True, loader=loader)
     assert_that(
-        graph.sentry_logging.dsn,
+        graph.sentry_logging_pubsub.dsn,
         is_(equal_to("topic")),
     )
 
@@ -49,7 +49,7 @@ def test_sentry_client_default_to_None_no_dsn_set():
     graph = create_object_graph("example", testing=True, loader=loader)
 
     assert_that(
-        graph.sentry_logging.enabled,
+        graph.sentry_logging_pubsub.enabled,
         is_(equal_to(False)),
     )
 
@@ -94,7 +94,7 @@ def test_custom_before_send():
 
     def loader(metadata):
         return dict(
-            sentry_logging=dict(
+            sentry_logging_pubsub=dict(
                 dsn="topic",
                 enabled=True,
                 custom_before_send_func="microcosm_pubsub.tests.test_sentry._test_custom_before_send",
@@ -104,5 +104,5 @@ def test_custom_before_send():
     graph = create_object_graph("example", testing=True, loader=loader)
     graph.use("sentry_before_send")
 
-    client = graph.sentry_logging.client
+    client = graph.sentry_logging_pubsub.client
     assert_that(client.default_before_send(1, 1), "TESTING")

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
             "sqs_message_handler_registry = microcosm_pubsub.registry:configure_handler_registry",
             "sns_producer = microcosm_pubsub.producer:configure_sns_producer",
             "sns_topic_arns = microcosm_pubsub.producer:configure_sns_topic_arns",
-            "sentry_logging = microcosm_pubsub.sentry:configure_sentry",
+            "sentry_logging_pubsub = microcosm_pubsub.sentry:configure_sentry_pubsub",
         ],
     },
     tests_require=[


### PR DESCRIPTION
Problem:
`microcosm_pubsub` and `microcosm_flask` were registering to the same location in the graph. This was fine when they both held the exact same information and this was static. Since https://github.com/globality-corp/microcosm-pubsub/pull/245 this is no longer the case with configuration options specific to the pubsub context. When they were both enabled in an Application together the last one to register won. Which meant `pubsub` specific settings were lost when the `microcosm_flask` lost the race.

Solution:
Separate registration/configuration points in the graph. This is something I thought about from the start but opted to not duplicate the config. Actually prefer this now as it gives control over turning on/off each component independently. This is useful as some of the integrations are more noisy and less useful in pre-prod environments.