### PR TITLE
Cleanup: Remove Tornado, fix warning

### DIFF
--- a/microcosm_pubsub/tests/chain/test_context.py
+++ b/microcosm_pubsub/tests/chain/test_context.py
@@ -1,7 +1,7 @@
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     has_length,
     is_,
     raises,
@@ -66,7 +66,7 @@ class TestScopedSafeContext:
         )
         assert_that(
             list(self.context),
-            contains(
+            contains_exactly(
                 "arg2",
                 "arg",
             ),

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,10 @@ setup(
     zip_safe=False,
     python_requires=">=3.6",
     install_requires=[
-        "tornado<6",
         "boto3>=1.5.8",
         "dataclasses;python_version<'3.7'",
         "marshmallow>=3.0.0",
-        "microcosm>=2.12.0",
+        "microcosm>=3.0.0",
         "microcosm-caching>=0.2.0",
         "microcosm-daemon>=1.0.0",
         "microcosm-logging>=1.3.0",


### PR DESCRIPTION
- Since `microcosm>=3.0.0` has dropped jaeger remove the pinned `tornado` dependency.
- Fix a deprecation warning in pyhamcrest. `contains` -> `contains_exactly`