### PR TITLE
Add optional tracing with Dynatrace OneAgent

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ elif [ "$1" = "lint" ]; then
    flake8 ${NAME}
 elif [ "$1" = "typehinting" ]; then
    # Install standard type-linting dependencies
-   pip --quiet install mypy
+   pip --quiet install mypy types-requests
    mypy ${NAME} --ignore-missing-imports
 else
    echo "Cannot execute $@"

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -5,7 +5,7 @@ Message consumer.
 from os.path import exists
 from urllib.parse import urlparse
 
-from boto3 import Session
+from boto3.session import Session
 from microcosm.api import defaults, typed
 from microcosm_logging.decorators import logger
 

--- a/microcosm_pubsub/errors.py
+++ b/microcosm_pubsub/errors.py
@@ -53,7 +53,7 @@ class IgnoreMessage(Exception):
 
 class TTLExpired(Exception):
     """
-    Control-flow exception to skip messages in infinte loop.
+    Control-flow exception to skip messages in infinite loop.
 
     """
     def __init__(self, reason=None, extra=None):

--- a/microcosm_pubsub/sentry.py
+++ b/microcosm_pubsub/sentry.py
@@ -99,7 +99,7 @@ def configure_sentry_pubsub(graph: ObjectGraph) -> SentryConfigPubsub:
             sentry = MagicMock(**sentry_kwargs)
         else:
             try:
-                sentry = sentry_sdk.init(**sentry_kwargs)
+                sentry = sentry_sdk.init(**sentry_kwargs)  # type: ignore
             except BadDsn:
                 enabled, dsn, sentry = False, None, None
                 configure_sentry_pubsub.logger.error("Bad DSN value set")

--- a/microcosm_pubsub/tests/test_tracing.py
+++ b/microcosm_pubsub/tests/test_tracing.py
@@ -1,0 +1,128 @@
+import json
+from unittest.mock import ANY, patch
+
+from hamcrest import assert_that, equal_to
+from microcosm.api import create_object_graph
+
+from microcosm_pubsub import tracing
+from microcosm_pubsub.message import SQSMessage
+from microcosm_pubsub.result import MessageHandlingResultType
+from microcosm_pubsub.tests.fixtures import DerivedSchema, ExampleDaemon
+
+
+def test_trace_message_publish():
+    def loader(metadata):
+        return dict(
+            sns_topic_arns=dict(
+                default="topic-name",
+            )
+        )
+
+    graph = create_object_graph("example", testing=True, loader=loader)
+    graph.sns_producer.sns_client.publish.return_value = dict(MessageId="message-id-1234")
+
+    with patch.object(tracing, "oneagent") as oneagent, \
+            patch.object(tracing, "ChannelType"), \
+            patch.object(tracing, "Channel") as channel, \
+            patch.object(tracing, "MessagingDestinationType") as messagingdestinationtype:
+        sdk = oneagent.get_sdk.return_value
+        tracer_manager = sdk.trace_outgoing_message.return_value
+        tracer_obj = tracer_manager.__enter__.return_value
+        tracer_obj.outgoing_dynatrace_string_tag = "tag-1234"
+
+        message_id = graph.sns_producer.produce(
+            DerivedSchema.MEDIA_TYPE,
+            data="data",
+            opaque_data={"X-Request-Id": "req-id-1234"}
+        )
+        assert_that(message_id, equal_to("message-id-1234"))
+
+        graph.sns_producer.sns_client.publish.assert_called_once_with(
+            Message=ANY,
+            MessageAttributes=dict(
+                media_type=dict(
+                    DataType='String',
+                    StringValue='application/vnd.microcosm.derived'
+                ),
+            ),
+            TopicArn='topic-name'
+        )
+        message = json.loads(graph.sns_producer.sns_client.publish.call_args[1]['Message'])
+        assert_that(message["opaqueData"]["X-Request-Id"], equal_to("req-id-1234"))
+        assert_that(message["opaqueData"]["x-dynatrace"], equal_to("tag-1234"))
+
+        sdk.create_messaging_system_info.assert_called_once_with(
+            "SNS",
+            "topic-name",
+            messagingdestinationtype.TOPIC,
+            channel.return_value
+        )
+        sdk.trace_outgoing_message.assert_called_once_with(
+            sdk.create_messaging_system_info.return_value
+        )
+
+        tracer_manager.__enter__.assert_called_once_with()
+        tracer_obj.set_vendor_message_id.assert_called_once_with(
+            "message-id-1234"
+        )
+        tracer_obj.set_correlation_id.assert_called_once_with(
+            "req-id-1234"
+        )
+        tracer_manager.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_trace_message_dispatch():
+    daemon = ExampleDaemon.create_for_testing()
+    graph = daemon.graph
+    dispatcher = graph.sqs_message_dispatcher
+    content = dict(
+        bar="baz",
+        uri="http://example.com",
+        opaque_data={
+            "X-Request-Id": "req-id-5678",
+            "x-dynatrace": "tag-5678",
+        }
+    )
+    message = SQSMessage(
+        approximate_receive_count=0,
+        consumer=graph.sqs_consumer,
+        content=content,
+        media_type=DerivedSchema.MEDIA_TYPE,
+        message_id="message-id-5678",
+        receipt_handle=None,
+    )
+    graph.sqs_consumer.sqs_client.reset_mock()
+
+    with patch.object(tracing, "oneagent") as oneagent, \
+            patch.object(tracing, "ChannelType"), \
+            patch.object(tracing, "Channel") as channel, \
+            patch.object(tracing, "MessagingDestinationType") as messagingdestinationtype:
+
+        result = dispatcher.handle_message(
+            message=message,
+            bound_handlers=daemon.bound_handlers,
+        )
+        assert_that(result.result, equal_to(MessageHandlingResultType.SUCCEEDED))
+
+        sdk = oneagent.get_sdk.return_value
+
+        sdk.create_messaging_system_info.assert_called_once_with(
+            "SQS",
+            "queue",
+            messagingdestinationtype.QUEUE,
+            channel.return_value
+        )
+        sdk.trace_incoming_message_process.assert_called_once_with(
+            sdk.create_messaging_system_info.return_value,
+            str_tag="tag-5678",
+        )
+        tracer_manager = sdk.trace_incoming_message_process.return_value
+        tracer_manager.__enter__.assert_called_once_with()
+        tracer_obj = tracer_manager.__enter__.return_value
+        tracer_obj.set_vendor_message_id.assert_called_once_with(
+            "message-id-5678"
+        )
+        tracer_obj.set_correlation_id.assert_called_once_with(
+            "req-id-5678"
+        )
+        tracer_manager.__exit__.assert_called_once_with(None, None, None)

--- a/microcosm_pubsub/tracing.py
+++ b/microcosm_pubsub/tracing.py
@@ -1,0 +1,96 @@
+"""
+Support optional tracing using Dynatrace oneagent.
+
+If the dynatrace SDK is not installed, does nothing.
+
+"""
+import json
+from contextlib import contextmanager
+
+from microcosm.opaque import Opaque
+
+from microcosm_pubsub.message import SQSMessage
+
+
+try:
+    import oneagent
+    from oneagent.common import ChannelType, MessagingDestinationType
+    from oneagent.sdk import Channel
+except ImportError:
+    oneagent = None
+    ChannelType = None
+    MessagingDestinationType = None
+    Channel = None
+
+
+AWS_SNS = "SNS"
+AWS_SQS = "SQS"
+OPAQUE_TAG_KEY = "x-dynatrace"
+
+
+class StubOutgoingTracer:
+    outgoing_dynatrace_string_tag = None
+
+    def set_vendor_message_id(self, id):
+        pass
+
+    def set_correlation_id(self, id):
+        pass
+
+
+def add_trace_to_message(tracer, pubsub_message):
+    tag = tracer.outgoing_dynatrace_string_tag
+    if tag:
+        try:
+            message = json.loads(pubsub_message.message)
+            message["opaqueData"][OPAQUE_TAG_KEY] = tag
+            pubsub_message.message = json.dumps(message)
+        except Exception:
+            pass
+
+
+@contextmanager
+def trace_outgoing_message(topic_arn: str):
+    if not oneagent:
+        yield StubOutgoingTracer()
+    else:
+        sdk = oneagent.get_sdk()
+        try:
+            topic_name = topic_arn.split(":")[-1]
+        except IndexError:
+            topic_name = topic_arn
+
+        messaging_system = sdk.create_messaging_system_info(
+            AWS_SNS,
+            topic_name,
+            MessagingDestinationType.TOPIC,
+            Channel(ChannelType.TCP_IP, None),
+        )
+        with sdk.trace_outgoing_message(messaging_system) as tracer:
+            yield tracer
+
+
+@contextmanager
+def trace_incoming_message_process(opaque: Opaque, message: SQSMessage, queue_url: str):
+    if not oneagent:
+        yield
+    else:
+        try:
+            queue_name = queue_url.split("/")[-1]
+        except IndexError:
+            queue_name = queue_url
+
+        sdk = oneagent.get_sdk()
+        messaging_system = sdk.create_messaging_system_info(
+            AWS_SQS,
+            queue_name,
+            MessagingDestinationType.QUEUE,
+            Channel(ChannelType.TCP_IP, None),
+        )
+        tag = opaque.get(OPAQUE_TAG_KEY)
+        request_id = opaque.get("X-Request-Id")
+        with sdk.trace_incoming_message_process(messaging_system, str_tag=tag) as tracer:
+            tracer.set_vendor_message_id(message.message_id)
+            if request_id:
+                tracer.set_correlation_id(request_id)
+            yield


### PR DESCRIPTION
If the Dynatrace OneAgent SDK is installed, instrument messages sent
and received.

If it is not installed, silently do nothing instead.