### PR TITLE
Add message receipt to opaque data

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.25.1
+current_version = 2.26.0
 commit = False
 tag = False
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,34 @@
 #
 version: 2.1
 
+
+executors:
+  node-executor:
+    working_directory: ~/repo
+    docker:
+      - image: cimg/node:14.19.0
+        environment:
+          EXTRA_INDEX_URL: "InjectedDuringRuntime"
+          AWS_ECR_DOMAIN: "InjectedDuringRuntime"
+          JFROG_AUTH: "InjectedDuringRuntime"
+          APOLLO_ENGINE_API_KEY: "InjectedDuringRuntime"
+
+  globality-build-executor:
+    working_directory: ~/repo
+    docker:
+      - image: ${AWS_ECR_DOMAIN}/globality-build:2022.23.1
+        aws_auth:
+          aws_access_key_id: ${AWS_ACCESS_KEY_ID}
+          aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+        environment:
+          EXTRA_INDEX_URL: "InjectedDuringRuntime"
+          AWS_ECR_DOMAIN: "InjectedDuringRuntime"
+          JFROG_AUTH: "InjectedDuringRuntime"
+
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:2020.51.0
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2022.23.1
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -30,7 +54,7 @@ defaults: &defaults
 deploy_defaults: &deploy_defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:2020.51.0
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2022.23.1
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -53,6 +77,7 @@ jobs:
 
     steps:
       - checkout
+
 
       - persist_to_workspace:
           root: ~/repo
@@ -88,6 +113,7 @@ jobs:
 
             docker push $AWS_ECR_DOMAIN/python-library:$CIRCLE_SHA1
 
+
   test:
     <<: *defaults
 
@@ -103,6 +129,7 @@ jobs:
           name: Login AWS ECR
           command: |
             aws ecr get-login-password --region ${AWS_DEFAULT_REGION} | docker login --username AWS --password-stdin ${AWS_ECR_DOMAIN}
+
 
       - run:
           name: Copy service tests to volume
@@ -177,15 +204,31 @@ jobs:
           command: |
             docker run -it --volumes-from service_tests ${AWS_ECR_DOMAIN}/python-library:${CIRCLE_SHA1} typehinting
 
+
+
   deploy_jfrog_rc:
     <<: *defaults
     steps:
       - attach_workspace:
           at: ~/repo
       - run:
-          name: Deploy
+          name: Deploy  # If package publishing enabled, always push RCs to JFrog
           command: |
-            echo "Not publishing package!"
+            echo "[distutils]" > ~/.pypirc
+            echo "index-servers =" >> ~/.pypirc
+            echo "    jfrog" >> ~/.pypirc
+            echo >> ~/.pypirc
+            echo "[jfrog]" >> ~/.pypirc
+            echo "repository:https://globality.jfrog.io/globality/api/pypi/pypi" >> ~/.pypirc
+            echo "username:$JFROG_USERNAME" >> ~/.pypirc
+            echo "password:$JFROG_PASSWORD" >> ~/.pypirc
+            echo >> ~/.pypirc
+            echo >> ~/.pypirc
+            version=2.${CIRCLE_BUILD_NUM}.dev${CIRCLE_BUILD_NUM}
+            sed  -i '/version \=/s/\".*\"/'"\"${version}\"/" setup.py
+            python setup.py register -r jfrog
+            python setup.py sdist
+            twine upload --repository jfrog dist/microcosm-pubsub-${version}.tar.gz
 
   publish_library:
     <<: *defaults
@@ -200,7 +243,7 @@ jobs:
             echo "    pypi " >> ~/.pypirc
             echo >> ~/.pypirc
             echo "[pypi]" >> ~/.pypirc
-            echo "repository:https://upload.pypi.org/legacy/" >> ~/.pypirc
+            echo "repository = https://upload.pypi.org/legacy/" >> ~/.pypirc
             echo "username = __token__" >> ~/.pypirc
             echo "password = ${PYPI_AUTH_TOKEN}" >> ~/.pypirc
             echo >> ~/.pypirc
@@ -210,19 +253,20 @@ jobs:
             twine upload --repository pypi dist/microcosm-pubsub-${version}.tar.gz
 
 
+
 workflows:
 
   build-and-release:
     jobs:
       - checkout:
-          context: 
+          context:
           - Globality-Common
           filters:
             # run for all branches and tags
             tags:
               only: /.*/
       - build_docker:
-          context: 
+          context:
           - Globality-Common
           requires:
             - checkout
@@ -231,7 +275,7 @@ workflows:
             tags:
               only: /.*/
       - lint:
-          context: 
+          context:
           - Globality-Common
           requires:
             - build_docker
@@ -240,7 +284,7 @@ workflows:
             tags:
               only: /.*/
       - test:
-          context: 
+          context:
           - Globality-Common
           requires:
             - build_docker
@@ -249,14 +293,14 @@ workflows:
             tags:
               only: /.*/
       - deploy_jfrog_rc:
-          context: 
+          context:
           - Globality-Common
           requires:
             - test
             - lint
             - typehinting
       - typehinting:
-          context: 
+          context:
           - Globality-Common
           requires:
             - build_docker
@@ -265,8 +309,9 @@ workflows:
             tags:
               only: /.*/
       - publish_library:
-          context: 
+          context:
           - Globality-Common
+          - Python-Context
           requires:
             - test
             - lint
@@ -276,5 +321,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^[0-9]+(\.[0-9]+)*/
-
-

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,9 +6,10 @@ microcosm_pubsub/tests
 !MANIFEST.in
 !README.md
 !HISTORY.rst
-!requirements.txt
+!requirements*.txt
 !setup.py
 !setup.cfg
+!mypy.ini
 !pyproject.toml
 !conftest.py
 **/*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ nosetests.xml
 coverage.xml
 *,cover
 cover
+microcosm_pubsub/tests/test-results/
 
 # Translations
 *.mo

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -1,10 +1,19 @@
 {
   "params": {
+    "docker": {
+      "docker_tag": "python:3.7-slim-bullseye"
+    },
+    "entrypoint": {
+      "pre_typehinting_commands": [
+        "pip install types-requests"
+      ]
+    },
     "name": "microcosm-pubsub",
     "pypi": {
       "repository": "pypi"
-    }
+    },
+    "test_command": "pytest"
   },
   "type": "python-library",
-  "version": "2020.51.0"
+  "version": "2022.23.1"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@
 #
 
 # ----------- deps -----------
-# Install from Debian Stretch with modern Python support
-FROM python:slim-stretch as deps
+FROM python:3.7-slim-bullseye as deps
 
 #
 # Most services will use the same set of packages here, though a few will install
@@ -84,7 +83,6 @@ RUN pip install --no-cache-dir --upgrade --extra-index-url ${EXTRA_INDEX_URL} /s
     apt-get remove --purge -y ${BUILD_PACKAGES} && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
-
 
 # ----------- final -----------
 FROM base

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/bash -e
 
+#  This file is auto generated with globality-build.
+#  You should not make any changes to this file manually
+#
+#  See: http://github.com/globality-corp/globality-build
+
 # Container entrypoint to simplify running the production and dev servers.
 
 # Entrypoint conventions are as follows:
@@ -21,17 +26,18 @@
 if [ "$1" = "test" ]; then
    # Install standard test dependencies; YMMV
    pip --quiet install \
-       .[test] nose PyHamcrest coverage
-   exec nosetests
+       .[test] pytest pytest-cov PyHamcrest
+   pytest
 elif [ "$1" = "lint" ]; then
    # Install standard linting dependencies; YMMV
    pip --quiet install \
-       .[lint] "isort<5.0.0" flake8 flake8-print flake8-logging-format flake8-isort
-   flake8 ${NAME}
+       .[lint]
+   exec flake8 ${NAME}
 elif [ "$1" = "typehinting" ]; then
+   pip install types-requests
    # Install standard type-linting dependencies
-   pip --quiet install mypy types-requests
-   mypy ${NAME} --ignore-missing-imports
+   pip --quiet install mypy
+   exec mypy ${NAME} --ignore-missing-imports
 else
    echo "Cannot execute $@"
    exit 3

--- a/microcosm_pubsub/constants.py
+++ b/microcosm_pubsub/constants.py
@@ -7,3 +7,4 @@ DEFAULT_RESOURCE_CACHE_TTL = 60
 PUBLISHED_KEY = "X-Request-Published"
 TTL_KEY = "X-Request-Ttl"
 URI_KEY = "uri"
+RECEIPT_HANDLE_KEY = 'receipt_handle'

--- a/microcosm_pubsub/context.py
+++ b/microcosm_pubsub/context.py
@@ -8,7 +8,7 @@ from microcosm.api import defaults, typed
 from microcosm.config.types import boolean
 from microcosm_logging.decorators import logger
 
-from microcosm_pubsub.constants import TTL_KEY, URI_KEY
+from microcosm_pubsub.constants import RECEIPT_HANDLE_KEY, TTL_KEY, URI_KEY
 from microcosm_pubsub.message import SQSMessage
 
 
@@ -50,5 +50,9 @@ class SQSMessageContext:
         # include the URI (if there is one)
         if message.uri:
             context[URI_KEY] = message.uri
+
+        # include the receipt handle (if there is one)
+        if message.receipt_handle:
+            context[RECEIPT_HANDLE_KEY] = message.receipt_handle
 
         return context

--- a/microcosm_pubsub/tests/handlers/test_uri_handler.py
+++ b/microcosm_pubsub/tests/handlers/test_uri_handler.py
@@ -11,7 +11,6 @@ from hamcrest import (
 )
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_dict
-from nose.plugins.attrib import attr
 from requests.exceptions import InvalidSchema
 
 from microcosm_pubsub.constants import DEFAULT_RESOURCE_CACHE_TTL
@@ -109,7 +108,6 @@ class TestURIHandler:
             is_(equal_to("bar")),
         )
 
-    @attr("caching")
     def test_get_resource_with_cache_disabled_on_instance(self):
         config = dict(
             resource_cache=dict(
@@ -145,7 +143,6 @@ class TestURIHandler:
             headers=dict(),
         )
 
-    @attr("caching")
     def test_get_non_whitelisted_resource_with_cache_enabled(self):
         config = dict(
             resource_cache=dict(
@@ -189,7 +186,6 @@ class TestURIHandler:
         assert_that(mocked_cache_get.called, is_(equal_to(False)))
         assert_that(mocked_cache_set.called, is_(equal_to(False)))
 
-    @attr("caching")
     def test_get_whitelisted_resource_with_cache_enabled_and_cache_miss(self):
         config = dict(
             resource_cache=dict(
@@ -239,7 +235,6 @@ class TestURIHandler:
             ttl=DEFAULT_RESOURCE_CACHE_TTL,
         )
 
-    @attr("caching")
     def test_get_whitelisted_resource_with_cache_enabled_and_cache_miss_and_custom_ttl(self):
         config = dict(
             resource_cache=dict(
@@ -289,7 +284,6 @@ class TestURIHandler:
             ttl=100,
         )
 
-    @attr("caching")
     def test_get_whitelisted_resource_with_cache_enabled_and_cache_hit(self):
         config = dict(
             resource_cache=dict(

--- a/microcosm_pubsub/tests/test_context.py
+++ b/microcosm_pubsub/tests/test_context.py
@@ -26,7 +26,7 @@ class TestSQSMessageContext:
             ),
             media_type=None,
             message_id=MESSAGE_ID,
-            receipt_handle=None,
+            receipt_handle="receipt",
         )
 
     def test_includes_opaque_data(self):
@@ -53,6 +53,15 @@ class TestSQSMessageContext:
                 self.graph.opaque.as_dict(),
                 has_entries(
                     uri=MESSAGE_URI,
+                ),
+            )
+
+    def test_includes_receipt_handle(self):
+        with self.graph.opaque.initialize(self.graph.sqs_message_context, self.message):
+            assert_that(
+                self.graph.opaque.as_dict(),
+                has_entries(
+                    receipt_handle="receipt",
                 ),
             )
 

--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from hamcrest import assert_that, has_entries, has_properties
 from microcosm_logging.decorators import logger
-from parameterized import parameterized
+from pytest import mark
 
 from microcosm_pubsub.errors import (
     IgnoreMessage,
@@ -219,14 +219,17 @@ class TestMessageHandlingResult:
             self.graph.opaque,
         )
 
-    @parameterized([
-        (MessageHandlingResultType.FAILED, True),
-        (MessageHandlingResultType.EXPIRED, True),
-        (MessageHandlingResultType.SKIPPED, False),
-        (MessageHandlingResultType.SUCCEEDED, False),
-        (MessageHandlingResultType.IGNORED, False),
-        (MessageHandlingResultType.RETRIED, False),
-    ])
+    @mark.parametrize(
+        ['result_type', 'error_reported'],
+        [
+            (MessageHandlingResultType.FAILED, True),
+            (MessageHandlingResultType.EXPIRED, True),
+            (MessageHandlingResultType.SKIPPED, False),
+            (MessageHandlingResultType.SUCCEEDED, False),
+            (MessageHandlingResultType.IGNORED, False),
+            (MessageHandlingResultType.RETRIED, False),
+        ],
+    )
     def test_error_reporting_only_sends_on_relevant_result_type(self, result_type, error_reported):
         result = MessageHandlingResult(result=result_type, media_type="media", exc_info=(1, 2, 3))
         sentry_config = SentryConfigPubsub(enabled=True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
-exclude = */migrations/*,.eggs/*
 max-line-length = 120
 max-complexity = 15
+exclude = */migrations/*,.eggs/*
 
 [isort]
 combine_as_imports = True
@@ -9,7 +9,6 @@ force_grid_wrap = 4
 float_to_top = True
 include_trailing_comma = True
 known_first_party = microcosm_pubsub
-known_third_party = six,hamcrest,parameterized,marshmallow,microcosm,unidecode,nose
 extra_standard_library = pkg_resources
 line_length = 99
 lines_after_imports = 2
@@ -30,6 +29,7 @@ cover-erase = True
 addopts =
     --cov microcosm_pubsub
     --cov-report xml:microcosm_pubsub/tests/coverage/cov.xml
+    --junitxml=microcosm_pubsub/tests/test-results/pytest/junit.xml
 
 [coverage:report]
 show_missing = True

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "2.25.1"
+version = "2.26.0"
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,14 @@ setup(
         "metrics": "microcosm-metrics>=2.5.0",
         "sentry": "sentry-sdk>=0.14.4",
         "test": [
+            "pytest",
+            "pytest-cov",
             "sentry-sdk>=0.14.4",
             "PyHamcrest",
-            "coverage",
-            "parameterized",
         ],
+        "lint": [
+            "flake8",
+        ]
     },
     setup_requires=[
         "nose>=1.3.6",
@@ -62,10 +65,4 @@ setup(
             "sentry_logging_pubsub = microcosm_pubsub.sentry:configure_sentry_pubsub",
         ],
     },
-    tests_require=[
-        "coverage>=3.7.1",
-        "parameterized>=0.7.0",
-        "PyHamcrest>=1.8.5",
-        "parameterized>=0.7.4",
-    ],
 )


### PR DESCRIPTION
* Include the message receipt handle in context

Add the receipt handle to the SQS message context that is included in opaque data. The message receipt handle is required for handlers to change the visibility timeout of the message, but is not part of the message content that they are passed.

Include the receipt handle as part of the message context.

* Update build files

Update build files to get access to dev packages, with related changes: configure docker image, use current mypy, switch to pytest.

* Bump version
