### PR TITLE
Allow a reason and extras when creating result from Nack exception

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.26.0
+current_version = 2.27.0
 commit = False
 tag = False
 

--- a/microcosm_pubsub/errors.py
+++ b/microcosm_pubsub/errors.py
@@ -20,13 +20,17 @@ class Nack(Exception):
     and the SQS dead letter queue (DLQ) configuration, if any.
 
     """
-    def __init__(self, visibility_timeout_seconds, reason="", extra=None):
+    def __init__(self, visibility_timeout_seconds, reason=None, extra=None):
         super().__init__(reason)
         self.visibility_timeout_seconds = visibility_timeout_seconds
         self.extra = extra or dict()
 
     def __repr__(self):
-        return "Nack({})".format(self.visibility_timeout_seconds)
+        return "Nack(visibility_timeout_seconds={timeout}, reason={reason}, extra={extra})".format(
+            timeout=self.visibility_timeout_seconds,
+            reason=str(self),
+            extra=self.extra,
+        )
 
 
 class SkipMessage(Exception):

--- a/microcosm_pubsub/errors.py
+++ b/microcosm_pubsub/errors.py
@@ -20,8 +20,10 @@ class Nack(Exception):
     and the SQS dead letter queue (DLQ) configuration, if any.
 
     """
-    def __init__(self, visibility_timeout_seconds):
+    def __init__(self, visibility_timeout_seconds, reason="", extra=None):
+        super().__init__(reason)
         self.visibility_timeout_seconds = visibility_timeout_seconds
+        self.extra = extra or dict()
 
     def __repr__(self):
         return "Nack({})".format(self.visibility_timeout_seconds)

--- a/microcosm_pubsub/result.py
+++ b/microcosm_pubsub/result.py
@@ -128,6 +128,10 @@ class MessageHandlingResult:
 
         if isinstance(error, Nack):
             return cls(
+                extra=dict(
+                    reason=str(error),
+                    **error.extra
+                ),
                 media_type=message.media_type,
                 result=MessageHandlingResultType.RETRIED,
                 retry_timeout_seconds=error.visibility_timeout_seconds,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     install_requires=[
         "boto3>=1.5.8",
         "dataclasses;python_version<'3.7'",
-        "flake8<=4.0.1"
         "marshmallow>=3.0.0",
         "microcosm>=3.0.0",
         "microcosm-caching>=0.2.0",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     install_requires=[
         "boto3>=1.5.8",
         "dataclasses;python_version<'3.7'",
-        "flake8<5"
         "marshmallow>=3.0.0",
         "microcosm>=3.0.0",
         "microcosm-caching>=0.2.0",
@@ -28,6 +27,12 @@ setup(
         "microcosm-logging>=1.3.0",
     ],
     extras_require={
+        "lint": [
+            "isort",
+            "flake8<5.0.0",
+            "flake8-print",
+            "flake8-isort",
+        ],
         "metrics": "microcosm-metrics>=2.5.0",
         "sentry": "sentry-sdk>=0.14.4",
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         "boto3>=1.5.8",
         "dataclasses;python_version<'3.7'",
+        "flake8<5"
         "marshmallow>=3.0.0",
         "microcosm>=3.0.0",
         "microcosm-caching>=0.2.0",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "2.26.0"
+version = "2.27.0"
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         "boto3>=1.5.8",
         "dataclasses;python_version<'3.7'",
+        "flake8<=4.0.1"
         "marshmallow>=3.0.0",
         "microcosm>=3.0.0",
         "microcosm-caching>=0.2.0",
@@ -27,12 +28,6 @@ setup(
         "microcosm-logging>=1.3.0",
     ],
     extras_require={
-        "lint": [
-            "isort",
-            "flake8<5.0.0",
-            "flake8-print",
-            "flake8-isort",
-        ],
         "metrics": "microcosm-metrics>=2.5.0",
         "sentry": "sentry-sdk>=0.14.4",
         "test": [


### PR DESCRIPTION
Allow an optional `reason` and `extras` when creating a result from a Nack exception. This will allow us to include additional information in logs when Nacks are raised by handlers -- which become RETRIED messages.

Here's an example using `reason` (see the `log_reason` field):
![Screen Shot 2022-07-25 at 5 16 40 PM](https://user-images.githubusercontent.com/85182117/182696685-79296eee-07b9-468c-8978-00f53fa61c9e.png)
^^ from https://github.com/globality-corp/euclides/pull/463

Closes [GLOB-66164](https://globality.atlassian.net/browse/GLOB-66164)