### PR TITLE
Fix circleci build badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 PubSub with SNS/SQS
 
-[![Circle CI](https://circleci.com/gh/globality-corp/microcosm-pubsub/tree/develop.svg?style=svg)](https://circleci.com/gh/globality-corp/microcosm-pubsub/tree/develop)
-
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/globality-corp/microcosm-pubsub/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/globality-corp/microcosm-pubsub/tree/master)
 
 ## Conventions
 


### PR DESCRIPTION
- update build badge markdown in README

Why?

Badge has been broken since the default branch was changed from develop
to master.