### PR TITLE
Add Nack reasons when retrieving message URI resource

### DIFF
--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -161,11 +161,14 @@ class URIHandler(metaclass=ABCMeta):
         return None
 
     def validate_changed_field(self, message, resource):
-        if message.get('field_name') and self.nack_if_not_found:
+        if message.get("field_name") and self.nack_if_not_found:
             field_name = message["field_name"]
             new_value = message["new_value"]
             if resource.get(field_name) != new_value:
-                raise Nack(self.resource_nack_timeout)
+                raise Nack(
+                    self.resource_nack_timeout,
+                    reason="Resource field value does not match message",
+                )
 
     def get_resource(self, message, uri):
         """
@@ -195,7 +198,10 @@ class URIHandler(metaclass=ABCMeta):
             )
             raise
         if response.status_code == codes.not_found and self.nack_if_not_found:
-            raise Nack(self.resource_nack_timeout)
+            raise Nack(
+                self.resource_nack_timeout,
+                reason="URI resource not found",
+            )
         response.raise_for_status()
         response_json = response.json()
 

--- a/microcosm_pubsub/tests/handlers/test_uri_handler.py
+++ b/microcosm_pubsub/tests/handlers/test_uri_handler.py
@@ -398,7 +398,10 @@ class TestURIHandler:
             handler = URIHandler(graph)
             assert_that(
                 calling(handler.get_resource).with_args(message, uri),
-                raises(Nack),
+                raises(
+                    Nack,
+                    "URI resource not found",
+                ),
             )
 
     def test_nack_when_changed_field_not_equal(self):
@@ -421,7 +424,10 @@ class TestURIHandler:
             handler = URIHandler(graph)
             assert_that(
                 calling(handler.get_resource).with_args(message, uri),
-                raises(Nack),
+                raises(
+                    Nack,
+                    "Resource field value does not match message",
+                ),
             )
 
     def test_handle_when_changed_field_is_equal(self):


### PR DESCRIPTION
## What?

- update uri_handler to include reason value when raising Nack

## Why?

Without the reason, determining why a handler nacked is harder than it
needs to be.