### PR TITLE
Allow for configurable exponential backoff

### DIFF
--- a/microcosm_pubsub/backoff.py
+++ b/microcosm_pubsub/backoff.py
@@ -47,12 +47,12 @@ class ExponentialBackoffPolicy(BackoffPolicy):
     Uses a timeout scaled between 1 and an exponential limit.
 
     """
-    def __init__(self, **kwargs):
-        pass
+    def __init__(self, backoff_factor=2.0, **kwargs):
+        self.backoff_factor = backoff_factor
 
     def compute_backoff_timeout(self, message, message_timeout):
-        # exponential backoff means that on the Cth failure, timeout is maximized at N=2^C - 1
-        upper = 2**message.approximate_receive_count - 1
+        # exponential backoff means that on the Cth failure, timeout is maximized at N=backoff_factor^C - 1
+        upper = int(self.backoff_factor**message.approximate_receive_count) - 1
 
         # randomly select a timeout between 1..N; note that proper exponential backoff uses 0..N
         scaling_factor = self.randint(1, upper)

--- a/microcosm_pubsub/consumer.py
+++ b/microcosm_pubsub/consumer.py
@@ -133,6 +133,8 @@ def configure_sqs_client(graph):
     wait_seconds=typed(int, default_value=1),
     # On error, change the visibility timeout when nacking
     message_retry_visibility_timeout_seconds=typed(int, default_value=5),
+    # For ExponentialBackoffStrategy include a number as a factor
+    message_exponential_backoff_factor=typed(float, default_value=2.0),
 )
 def configure_sqs_consumer(graph):
     """
@@ -160,6 +162,7 @@ def configure_sqs_consumer(graph):
 
     backoff_policy = backoff_policy_class(
         message_retry_visibility_timeout_seconds=graph.config.sqs_consumer.message_retry_visibility_timeout_seconds,
+        message_exponential_backoff_factor=graph.config.sqs_consumer.message_exponential_backoff_factor,
     )
 
     return SQSConsumer(

--- a/microcosm_pubsub/tests/test_backoff.py
+++ b/microcosm_pubsub/tests/test_backoff.py
@@ -64,3 +64,19 @@ def test_scaled_exponential_timeout():
         )
 
         mocked.assert_called_with(1, 3)
+
+def test_scaled_exponential_timeout():
+    message = SQSMessage(
+        None, None, None, None, None,
+        approximate_receive_count=2.5,
+    )
+    backoff_policy = ExponentialBackoffPolicy(backoff_factor=3)
+
+    with patch.object(backoff_policy, "randint") as mocked:
+        mocked.return_value = 14
+        assert_that(
+            backoff_policy.compute_backoff_timeout(message, None),
+            is_(equal_to(14)),
+        )
+
+        mocked.assert_called_with(1, 14)

--- a/microcosm_pubsub/tests/test_backoff.py
+++ b/microcosm_pubsub/tests/test_backoff.py
@@ -65,7 +65,7 @@ def test_scaled_exponential_timeout():
 
         mocked.assert_called_with(1, 3)
 
-def test_scaled_exponential_timeout():
+def test_scaled_exponential_timeout_with_configurable_backoff():
     message = SQSMessage(
         None, None, None, None, None,
         approximate_receive_count=2.5,
@@ -80,3 +80,4 @@ def test_scaled_exponential_timeout():
         )
 
         mocked.assert_called_with(1, 14)
+


### PR DESCRIPTION
## What?
Allow configurable exponential backoff

## Why?
Because I want time between attempts grow faster - as currently 10 attempts are done within 17 minutes which is too short