### PR TITLE
Bumped microcosm and python

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.28.0
+current_version = 2.29.0
 commit = False
 tag = False
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@
 #
 
 # ----------- deps -----------
-FROM python:3.7-slim-bullseye as deps
+# Install from Debian bullseye with modern Python support
+FROM python:3.9-slim-bullseye as deps
 
 #
 # Most services will use the same set of packages here, though a few will install
@@ -22,7 +23,7 @@ FROM python:3.7-slim-bullseye as deps
 ARG EXTRA_INDEX_URL
 ENV EXTRA_INDEX_URL ${EXTRA_INDEX_URL}
 
-ENV CORE_PACKAGES locales
+ENV CORE_PACKAGES locales libpq-dev
 ENV BUILD_PACKAGES build-essential libffi-dev
 ENV OTHER_PACKAGES libssl-dev
 
@@ -101,7 +102,6 @@ ENTRYPOINT ["./entrypoint.sh"]
 # We should not need to reinstall dependencies here, but we do need to import
 # the distribution properly. We also save build arguments to the image using
 # microcosm-compatible environment variables.
-
 
 ARG BUILD_NUM
 ARG SHA1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,20 +24,15 @@
 
 
 if [ "$1" = "test" ]; then
-   # Install standard test dependencies; YMMV
-   pip --quiet install \
-       .[test] pytest pytest-cov PyHamcrest
-   pytest
+   pip install --no-cache-dir --upgrade --extra-index-url ${EXTRA_INDEX_URL} .\[build\]
+   shift
+   exec pytest "$@"
 elif [ "$1" = "lint" ]; then
-   # Install standard linting dependencies; YMMV
-   pip --quiet install \
-       .[lint]
+   pip install --no-cache-dir --upgrade --extra-index-url ${EXTRA_INDEX_URL} .\[build\]
    exec flake8 ${NAME}
 elif [ "$1" = "typehinting" ]; then
-   pip install types-requests
-   # Install standard type-linting dependencies
-   pip --quiet install mypy
-   exec mypy ${NAME} --ignore-missing-imports
+   pip install --no-cache-dir --upgrade --extra-index-url ${EXTRA_INDEX_URL} .\[build\]
+   exec mypy ${NAME}
 else
    echo "Cannot execute $@"
    exit 3

--- a/microcosm_pubsub/constants.py
+++ b/microcosm_pubsub/constants.py
@@ -4,7 +4,11 @@ Constants.
 """
 
 DEFAULT_RESOURCE_CACHE_TTL = 60
-PUBLISHED_KEY = "X-Request-Published"
-TTL_KEY = "X-Request-Ttl"
+PUBLISHED_KEY = "x-request-published"
+TTL_KEY = "x-request-ttl"
+REQUEST_ID_KEY = "x-request-id"
+OPAQUE_TAG_KEY = "x-dynatrace"
 URI_KEY = "uri"
-RECEIPT_HANDLE_KEY = 'receipt_handle'
+RECEIPT_HANDLE_KEY = "receipt_handle"
+AWS_SNS = "SNS"
+AWS_SQS = "SQS"

--- a/microcosm_pubsub/handlers/uri_handler.py
+++ b/microcosm_pubsub/handlers/uri_handler.py
@@ -8,8 +8,8 @@ from re import search
 from inflection import titleize
 from microcosm.errors import LockedGraphError, NotBoundError
 from microcosm_logging.decorators import logger
-from requests import codes, get
-from requests.exceptions import InvalidSchema
+from requests import codes, get  # type: ignore[import-untyped]
+from requests.exceptions import InvalidSchema  # type: ignore[import-untyped]
 
 from microcosm_pubsub.constants import DEFAULT_RESOURCE_CACHE_TTL
 from microcosm_pubsub.conventions.lifecycle import LifecycleChange

--- a/microcosm_pubsub/tests/chain/test_context.py
+++ b/microcosm_pubsub/tests/chain/test_context.py
@@ -29,7 +29,7 @@ class TestSafeContext:
 
 class TestScopedSafeContext:
 
-    def setup(self):
+    def setup_method(self):
         self.parent = SafeContext()
         self.parent["arg"] = 20
 

--- a/microcosm_pubsub/tests/conventions/test_conventions.py
+++ b/microcosm_pubsub/tests/conventions/test_conventions.py
@@ -20,7 +20,7 @@ def borked(resource, **kwargs):
 
 class TestConventions:
 
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph("test")
         self.graph.use(
             "pubsub_message_schema_registry",

--- a/microcosm_pubsub/tests/conventions/test_messages.py
+++ b/microcosm_pubsub/tests/conventions/test_messages.py
@@ -31,7 +31,7 @@ class Foo:
     pass
 
 
-class TestEnum(Enum):
+class FooEnum(Enum):
     key = auto()
 
     def __str__(self):
@@ -80,7 +80,7 @@ class CustomMessageSchema(URIMessageSchema):
 
     """
     MEDIA_TYPE = created("Resource")
-    enumField = EnumField(TestEnum, attribute="enum_field", required=True)
+    enumField = EnumField(FooEnum, attribute="enum_field", required=True)
 
 
 def test_encode_uri_message_schema():
@@ -116,7 +116,7 @@ def test_encode_custom_message():
     codec = PubSubMessageCodec(custom_schema)
     assert_that(
         loads(codec.encode(
-            enum_field=TestEnum.key,
+            enum_field=FooEnum.key,
             media_type=CustomMessageSchema.MEDIA_TYPE,
             opaque_data=dict(foo="bar"),
             uri="http://example.com",
@@ -222,7 +222,7 @@ def test_publish_by_uri_convention():
         "mediaType": "application/vnd.globality.pubsub._.created.foo",
         "uri": "http://example.com",
         "opaqueData": {
-            "X-Request-Published": published_time,
+            "x-request-published": published_time,
         },
     })))
     assert_that(graph.sns_producer.sns_client.publish.call_args[1]["MessageAttributes"], is_(equal_to({
@@ -258,7 +258,7 @@ def test_publish_by_identity_convention():
         "mediaType": "application/vnd.globality.pubsub._.deleted.foo",
         "id": "1",
         "opaqueData": {
-            "X-Request-Published": str(published_time),
+            "x-request-published": str(published_time),
         },
     })))
     assert_that(graph.sns_producer.sns_client.publish.call_args[1]["MessageAttributes"], is_(equal_to({

--- a/microcosm_pubsub/tests/conventions/test_naming.py
+++ b/microcosm_pubsub/tests/conventions/test_naming.py
@@ -2,26 +2,24 @@
 Naming tests.
 
 """
-from hamcrest import assert_that, equal_to, is_
+import pytest
 
 from microcosm_pubsub.conventions import make_media_type
 
 
-def test_make_media_type():
-    """
-    Media type construction should generate the correct type strings.
-
-    """
-    cases = [
+@pytest.mark.parametrize(
+    "args, kwargs, expected",
+    [
         (("foo",), dict(), "application/vnd.globality.pubsub._.created.foo"),
         (("foo",), dict(public=True), "application/vnd.globality.pubsub.created.foo"),
         (("foo",), dict(organization="example"), "application/vnd.example.pubsub._.created.foo"),
         (("FooBar",), dict(), "application/vnd.globality.pubsub._.created.foo_bar"),
         (("FooBar.ThisThat",), dict(), "application/vnd.globality.pubsub._.created.foo_bar.this_that"),
     ]
+)
+def test_make_media_type(args, kwargs, expected):
+    """
+    Media type construction should generate the correct type strings.
 
-    def validate(args, kargs, expected):
-        assert_that(make_media_type(*args, **kwargs), is_(equal_to(expected)))
-
-    for args, kwargs, expected in cases:
-        yield validate, args, kwargs, expected
+    """
+    assert make_media_type(*args, **kwargs) == expected

--- a/microcosm_pubsub/tests/handlers/test_uri_handler.py
+++ b/microcosm_pubsub/tests/handlers/test_uri_handler.py
@@ -11,7 +11,7 @@ from hamcrest import (
 )
 from microcosm.api import create_object_graph
 from microcosm.loaders import load_from_dict
-from requests.exceptions import InvalidSchema
+from requests.exceptions import InvalidSchema  # type: ignore[import-untyped]
 
 from microcosm_pubsub.constants import DEFAULT_RESOURCE_CACHE_TTL
 from microcosm_pubsub.errors import Nack
@@ -376,7 +376,7 @@ class TestURIHandler:
         mocked_get.assert_called_with(
             uri,
             headers={
-                "X-Request-Id": "request-id",
+                "x-request-id": "request-id",
             },
         )
 

--- a/microcosm_pubsub/tests/sentry_fixture.py
+++ b/microcosm_pubsub/tests/sentry_fixture.py
@@ -62,7 +62,7 @@ sample_event = {
          'message': 'Result for media type: application/vnd.globality.pubsub._.created.do_something was : FAILED ',
          'timestamp': '2020-05-16T11:01:35.983545Z',
          'data': {'media_type': 'application/vnd.globality.pubsub._.created.do_something',
-                  'message_id': 'message-id-b7fa5993-a966-4390-a6b1-ed9eb5026134', 'X-Request-Ttl': '31',
+                  'message_id': 'message-id-b7fa5993-a966-4390-a6b1-ed9eb5026134', 'x-request-ttl': '31',
                   'uri': 'http://localhost:5452/api/v2/message/6dee4da6-8af1-4636-93b6-7770bc6990bc',
                   'handler': 'Handler Test', 'elapsed_time': 47.17707633972168}, 'type': 'default'}
     ],

--- a/microcosm_pubsub/tests/test_context.py
+++ b/microcosm_pubsub/tests/test_context.py
@@ -14,7 +14,7 @@ MESSAGE_URI = "message_uri"
 
 class TestSQSMessageContext:
 
-    def setup(self):
+    def setup_method(self):
         self.graph = ExampleDaemon.create_for_testing().graph
         self.message = SQSMessage(
             consumer=self.graph.sqs_consumer,
@@ -70,18 +70,18 @@ class TestSQSMessageContext:
             assert_that(
                 self.graph.opaque.as_dict(),
                 has_entries({
-                    "X-Request-Ttl": "31",
+                    "x-request-ttl": "31",
                 }),
             )
 
     def test_updates_existing_ttl(self):
-        self.message.opaque_data["X-Request-Ttl"] = "10"
+        self.message.opaque_data["x-request-ttl"] = "10"
 
         with self.graph.opaque.initialize(self.graph.sqs_message_context, self.message):
             assert_that(
                 self.graph.opaque.as_dict(),
                 has_entries({
-                    "X-Request-Ttl": "9",
+                    "x-request-ttl": "9",
                 }),
             )
 

--- a/microcosm_pubsub/tests/test_decorators.py
+++ b/microcosm_pubsub/tests/test_decorators.py
@@ -14,7 +14,7 @@ from microcosm_pubsub.tests.fixtures import DuckTypeSchema, ExampleDaemon, noop_
 
 class TestDecorators:
 
-    def setup(self):
+    def setup_method(self):
         self.daemon = ExampleDaemon.create_for_testing()
         self.graph = self.daemon.graph
 

--- a/microcosm_pubsub/tests/test_dispatcher.py
+++ b/microcosm_pubsub/tests/test_dispatcher.py
@@ -17,7 +17,7 @@ MESSAGE_ID = "message-id"
 
 class TestDispatcher:
 
-    def setup(self):
+    def setup_method(self):
         self.daemon = ExampleDaemon.create_for_testing()
         self.graph = self.daemon.graph
 
@@ -71,7 +71,7 @@ class TestDispatcher:
         """
         self.message.content = dict(
             opaque_data={
-                "X-Request-Ttl": "0",
+                "x-request-ttl": "0",
             },
         )
         assert_that(

--- a/microcosm_pubsub/tests/test_matcher.py
+++ b/microcosm_pubsub/tests/test_matcher.py
@@ -17,7 +17,7 @@ from microcosm_pubsub.matchers import (
 
 class TestPublishingMatcherWithMockedSNS:
 
-    def setup(self):
+    def setup_method(self):
         loader = load_from_dict(
             sns_producer=dict(
                 # NB: mock the boto SNS client (default)
@@ -85,7 +85,7 @@ class TestPublishingMatcherWithMockedSNS:
 
 class TestPublishingMatcherWithoutMockedSNS:
 
-    def setup(self):
+    def setup_method(self):
         loader = load_from_dict(
             sns_producer=dict(
                 # NB: mock the SNS producer itself (non-default, except for daemons)

--- a/microcosm_pubsub/tests/test_producer.py
+++ b/microcosm_pubsub/tests/test_producer.py
@@ -112,7 +112,7 @@ def test_produce_default_topic():
         "data": "data",
         "mediaType": DerivedSchema.MEDIA_TYPE,
         "opaqueData": {
-            "X-Request-Published": published_time,
+            "x-request-published": published_time,
         },
     })))
     assert_that(message_id, is_(equal_to(MESSAGE_ID)))
@@ -150,7 +150,7 @@ def test_produce_custom_topic():
         "data": "data",
         "mediaType": DerivedSchema.MEDIA_TYPE,
         "opaqueData": {
-            "X-Request-Published": published_time,
+            "x-request-published": published_time,
         },
     })))
     assert_that(message_id, is_(equal_to(MESSAGE_ID)))

--- a/microcosm_pubsub/tests/test_registry.py
+++ b/microcosm_pubsub/tests/test_registry.py
@@ -60,7 +60,7 @@ class WildcardSchema(PubSubMessageSchema):
 
 class TestDerivedPubSubMessageCodecRegistry:
 
-    def setup(self):
+    def setup_method(self):
         self.graph = create_object_graph("test")
         self.registry = self.graph.pubsub_message_schema_registry
 
@@ -150,7 +150,7 @@ class TestDerivedPubSubMessageCodecRegistry:
 
 class TestDerivedSQSMessageHandlerRegistry:
 
-    def setup(self):
+    def setup_method(self):
         self.daemon = ExampleDaemon.create_for_testing()
         self.graph = self.daemon.graph
         self.registry = self.graph.sqs_message_handler_registry

--- a/microcosm_pubsub/tests/test_result.py
+++ b/microcosm_pubsub/tests/test_result.py
@@ -27,7 +27,7 @@ RECEIPT_HANDLE = "receipt-handle"
 @logger
 class TestMessageHandlingResult:
 
-    def setup(self):
+    def setup_method(self):
         self.graph = ExampleDaemon.create_for_testing().graph
         self.opaque = self.graph.opaque
         self.message = SQSMessage(

--- a/microcosm_pubsub/tests/test_tracing.py
+++ b/microcosm_pubsub/tests/test_tracing.py
@@ -33,7 +33,10 @@ def test_trace_message_publish():
         message_id = graph.sns_producer.produce(
             DerivedSchema.MEDIA_TYPE,
             data="data",
-            opaque_data={"X-Request-Id": "req-id-1234"}
+            opaque_data={
+                "X-Request-Id": "req-id-1234",
+                "x-rerquest-service": "foo",
+            }
         )
         assert_that(message_id, equal_to("message-id-1234"))
 
@@ -48,7 +51,8 @@ def test_trace_message_publish():
             TopicArn='topic-name'
         )
         message = json.loads(graph.sns_producer.sns_client.publish.call_args[1]['Message'])
-        assert_that(message["opaqueData"]["X-Request-Id"], equal_to("req-id-1234"))
+        assert_that(message["opaqueData"]["x-request-id"], equal_to("req-id-1234"))
+        assert_that(message["opaqueData"]["x-rerquest-service"], equal_to("foo"))
         assert_that(message["opaqueData"]["x-dynatrace"], equal_to("tag-1234"))
 
         sdk.create_messaging_system_info.assert_called_once_with(

--- a/microcosm_pubsub/tracing.py
+++ b/microcosm_pubsub/tracing.py
@@ -8,6 +8,7 @@ import json
 from contextlib import contextmanager
 
 from microcosm.opaque import Opaque
+from microcosm_pubsub.constants import AWS_SNS, AWS_SQS, OPAQUE_TAG_KEY, REQUEST_ID_KEY
 
 from microcosm_pubsub.message import SQSMessage
 
@@ -21,11 +22,6 @@ except ImportError:
     ChannelType = None
     MessagingDestinationType = None
     Channel = None
-
-
-AWS_SNS = "SNS"
-AWS_SQS = "SQS"
-OPAQUE_TAG_KEY = "x-dynatrace"
 
 
 class StubOutgoingTracer:
@@ -87,8 +83,9 @@ def trace_incoming_message_process(opaque: Opaque, message: SQSMessage, queue_ur
             MessagingDestinationType.QUEUE,
             Channel(ChannelType.TCP_IP, None),
         )
+
         tag = opaque.get(OPAQUE_TAG_KEY)
-        request_id = opaque.get("X-Request-Id")
+        request_id = opaque.get(REQUEST_ID_KEY)
         with sdk.trace_incoming_message_process(messaging_system, str_tag=tag) as tracer:
             tracer.set_vendor_message_id(message.message_id)
             if request_id:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,17 +13,9 @@ extra_standard_library = pkg_resources
 line_length = 99
 lines_after_imports = 2
 multi_line_output = 3
-skip = __init__.py
 
 [mypy]
 ignore_missing_imports = True
-
-[nosetests]
-with-coverage = True
-cover-package = microcosm_pubsub
-cover-html = True
-cover-html-dir = coverage
-cover-erase = True
 
 [tool:pytest]
 addopts =

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "2.28.0"
+version = "2.29.0"
 
 
 setup(
@@ -16,34 +16,29 @@ setup(
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     install_requires=[
         "boto3>=1.5.8",
         "dataclasses;python_version<'3.7'",
         "marshmallow>=3.0.0",
-        "microcosm>=3.0.0",
+        "microcosm>=3.4.0",
         "microcosm-caching>=0.2.0",
         "microcosm-daemon>=1.2.0",
         "microcosm-logging>=1.3.0",
+        "requests>=2.31.0"
     ],
     extras_require={
         "metrics": "microcosm-metrics>=2.5.0",
         "sentry": "sentry-sdk>=0.14.4",
-        "test": [
-            "pytest",
-            "pytest-cov",
-            "sentry-sdk>=0.14.4",
-            "PyHamcrest",
-        ],
-        "lint": [
+        "build": [
             "flake8",
+            "mypy",
+            "PyHamcrest",
+            "pytest-cov",
+            "pytest",
+            "sentry-sdk",
         ]
     },
-    setup_requires=[
-        "nose>=1.3.6",
-    ],
-    dependency_links=[
-    ],
     entry_points={
         "console_scripts": [
             "publish-naive = microcosm_pubsub.main:make_naive_message",


### PR DESCRIPTION
What?

- bumped Python to 3.9
- bumped microcosm
- added adjustments coming from the fact `graph.opaque` is normalized in `microcosm` since version `3.4`