### PR TITLE
Fixing batch publishing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.30.2
+current_version = 2.30.3
 commit = False
 tag = False
 

--- a/microcosm_pubsub/handlers/publish_batch_message.py
+++ b/microcosm_pubsub/handlers/publish_batch_message.py
@@ -31,5 +31,5 @@ class PublishBatchMessage:
             )
 
             self.sns_producer.publish_message(pubsub_message)
-        
+
         return True

--- a/microcosm_pubsub/handlers/publish_batch_message.py
+++ b/microcosm_pubsub/handlers/publish_batch_message.py
@@ -31,4 +31,5 @@ class PublishBatchMessage:
             )
 
             self.sns_producer.publish_message(pubsub_message)
-            return True
+        
+        return True

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm-pubsub"
-version = "2.30.2"
+version = "2.30.3"
 
 
 setup(


### PR DESCRIPTION
We need to return True once we've published all messages. Else we publish first one and leave the rest.